### PR TITLE
폰트 로드 되지 않는 오류 수정

### DIFF
--- a/Core/DesignSystem/Package.swift
+++ b/Core/DesignSystem/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
             name: "DesignSystem",
             dependencies: [
                 .product(name: "SnapKit", package: "SnapKit")
-            ]
+            ],
+            resources: [.process("Resources")]
         ),
         .testTarget(
             name: "DesignSystemTests",

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Font/Font.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Font/Font.swift
@@ -9,8 +9,16 @@ import UIKit
 
 public enum Font {
     
-    public enum Name: String {
-        case omyupretty = "OmyuPretty"
+    public enum Name {
+        case omyupretty
+        
+        var fileName: String {
+            return "OmyuPretty"
+        }
+        
+        var name: String {
+            return "omyu pretty"
+        }
     }
 
     public enum Size: CGFloat {
@@ -31,14 +39,18 @@ public enum Font {
     public struct TTFont {
         private let _name: Name
         private let _extension: Extension
-
+        
         init(name: Name = .omyupretty, extensions: Extension = .ttf) {
             self._name = name
             self._extension = extensions
         }
-
+        
         var name: String {
-            "\(_name.rawValue)"
+            "\(_name.name)"
+        }
+        
+        var fileName: String {
+            "\(_name.fileName)"
         }
 
         var `extension`: String {
@@ -48,10 +60,9 @@ public enum Font {
     
     /// 폰트 파일 등록
     /// - 앱 초기에 최초 한 번 실행됩니다.
-    // TODO: AppDelegate에 `Font.registerFonts()` 해야함
     public static func registerTTFont() {
-        let font: TTFont = TTFont()
-        Font.registerFont(fontName: font.name, fontExtension: font.extension)
+        let ttFont: TTFont = TTFont()
+        Font.registerFont(fontName: ttFont.fileName, fontExtension: ttFont.extension)
     }
     
 }

--- a/TwoToo/AppDelegate.swift
+++ b/TwoToo/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 박건우 on 2023/06/03.
 //
 
+import CoreKit
 import UIKit
 
 @main
@@ -14,6 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        Font.registerTTFont()
+        
         return true
     }
 

--- a/TwoToo/Info.plist
+++ b/TwoToo/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>OmyuPretty.ttf</string>
-	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/TwoToo/SceneDelegate.swift
+++ b/TwoToo/SceneDelegate.swift
@@ -5,6 +5,8 @@
 //  Created by 박건우 on 2023/06/03.
 //
 
+import CoreKit
+import SceneKit
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {


### PR DESCRIPTION
## 개요

- 폰트 오류 수정

## 변경사항

- 폰트를 리소스에 잡아주어야 등록 및 로드를 할 수 있습니다
- 폰트는 파일명이 폰트의 진짜 이름이 아닐 수도 있습니다. 파일명으로 폰트를 등록하고 폰트명으로 로드해야합니다.
- Info.plist 에서 UIAppFonts 를 잡아주지 않아도 되기에 삭제하였습니다.

cc @julia0926 

## 스크린샷

|body1|h1|
|:---:|:---:|
|![Simulator Screenshot - iPhone 14 Pro - 2023-06-16 at 14 30 15](https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/3fba68db-1500-41bf-8dd4-36bab6126e12)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-16 at 14 29 58](https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/4d7541cd-307c-4f4e-9e75-e672191a51ee)|

