### PR TITLE
♻️  팝업 뷰 레이아웃 정비 (딤 처리 추가)

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
@@ -10,12 +10,27 @@ import Util
 
 public final class TTPopup: UIView, UIComponentBased {
 
+    /// 팝업 표시시 딤 처리
+    lazy var dimView: UIView = {
+        let v = UIView()
+        v.backgroundColor = .black.withAlphaComponent(0.5)
+        
+        return v
+    }()
+    
+    lazy var contentView: UIView = {
+        let v = UIView()
+        v.layer.cornerRadius = 20
+        v.backgroundColor = .mainWhite
+        
+        return v
+    }()
+    
     lazy var stackView: UIStackView = {
         let v = UIStackView()
         v.axis = .vertical
         v.alignment = .center
         v.spacing = 37
-        self.addSubview(v)
         v.addArrangedSubviews(self.titleLabel, self.resultView, self.descriptionLabel, self.buttonStackView)
 
         return v
@@ -104,11 +119,25 @@ public final class TTPopup: UIView, UIComponentBased {
         self.leftButton = self.buttons.first ?? UIButton()
         self.rightButton = self.buttons.last ?? UIButton()
 
-        self.layer.cornerRadius = 20
-        self.backgroundColor = .mainWhite
+        self.addSubviews(
+            self.dimView,
+            self.contentView
+        )
+        self.contentView.addSubviews(
+            self.stackView
+        )
     }
 
     public func layout() {
+        self.dimView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        self.contentView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(51)
+            make.centerY.equalToSuperview()
+        }
+        
         self.stackView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(40)
             make.trailing.equalToSuperview().offset(-40)
@@ -118,6 +147,14 @@ public final class TTPopup: UIView, UIComponentBased {
 
         self.resultView.snp.makeConstraints { make in
             make.width.height.equalTo(100)
+        }
+    }
+    
+    public override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
+        self.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
 

--- a/TwoToo/ViewController.swift
+++ b/TwoToo/ViewController.swift
@@ -38,6 +38,26 @@ class ViewController: UIViewController {
         return v
     }()
     
+    lazy var popup: TTPopup = {
+        let v = TTPopup(
+            title: "Test",
+            resultView: self.popupContentView,
+            description: "테스트 입니다",
+            buttons: [self.leftButton]
+        )
+        return v
+    }()
+    
+    lazy var popupContentView: UIView = {
+        let v = UIView()
+        return v
+    }()
+    
+    lazy var leftButton: UIButton = {
+        let v = UIButton()
+        return v
+    }()
+    
     @objc func didTapShortToastTest() {
         Task { @MainActor in
             Toast.shared.makeToast("1")
@@ -59,6 +79,8 @@ class ViewController: UIViewController {
         self.stackView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+        
+        self.view.addSubview(self.popup)
     }
 }
 


### PR DESCRIPTION
## 개요

- 팝업 뷰의 레이아웃 세팅 부분을 수정합니다

## 변경사항

- 딤 처리를 추가합니다
- 세로 길이는 컨텐츠에 따라 길어지고, 가로는 양쪽 마진 51 로 세팅합니다
- 팝업이 뷰에 추가되는 순간 레이아웃을 직접 세팅해줌으로써, 사용처에서 사용되는 불필요한 레이아웃 세팅 코드를 줄입니다.

## 스크린샷
![Uploading Simulator Screenshot - iPhone 14 Pro - 2023-06-23 at 11.07.46.png…]()

