### PR TITLE
🐛 resultView 내에 화면 레이아웃을 못잡는 현상 수정

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
@@ -102,6 +102,10 @@ public final class TTPopup: UIView, UIComponentBased {
         self.resultView.addSubview(resultView)
         self.descriptionLabel.text = description
         self.buttonTitles = buttonTitles
+        
+        resultView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
 
         self.attribute()
         self.layout()
@@ -149,7 +153,8 @@ public final class TTPopup: UIView, UIComponentBased {
         }
 
         self.resultView.snp.makeConstraints { make in
-            make.width.height.equalTo(100)
+            make.height.equalTo(100)
+            make.width.equalToSuperview()
         }
     }
     

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
@@ -10,12 +10,27 @@ import Util
 
 public final class TTPopup: UIView, UIComponentBased {
 
+    /// 팝업 표시시 딤 처리
+    lazy var dimView: UIView = {
+        let v = UIView()
+        v.backgroundColor = .black.withAlphaComponent(0.5)
+        
+        return v
+    }()
+    
+    lazy var contentView: UIView = {
+        let v = UIView()
+        v.layer.cornerRadius = 20
+        v.backgroundColor = .mainWhite
+        
+        return v
+    }()
+    
     lazy var stackView: UIStackView = {
         let v = UIStackView()
         v.axis = .vertical
         v.alignment = .center
         v.spacing = 37
-        self.addSubview(v)
         v.addArrangedSubviews(self.titleLabel, self.resultView, self.descriptionLabel, self.buttonStackView)
 
         return v
@@ -104,11 +119,25 @@ public final class TTPopup: UIView, UIComponentBased {
         self.leftButton = self.buttons.first ?? UIButton()
         self.rightButton = self.buttons.last ?? UIButton()
 
-        self.layer.cornerRadius = 20
-        self.backgroundColor = .mainWhite
+        self.addSubviews(
+            self.dimView,
+            self.contentView
+        )
+        self.contentView.addSubviews(
+            self.stackView
+        )
     }
 
     public func layout() {
+        self.dimView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        self.contentView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(51)
+            make.centerY.equalToSuperview()
+        }
+        
         self.stackView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(40)
             make.trailing.equalToSuperview().offset(-40)
@@ -118,6 +147,14 @@ public final class TTPopup: UIView, UIComponentBased {
 
         self.resultView.snp.makeConstraints { make in
             make.width.height.equalTo(100)
+        }
+    }
+    
+    public override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
+        self.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
 

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
@@ -89,19 +89,19 @@ public final class TTPopup: UIView, UIComponentBased {
         return v
     }()
 
-    var buttons = [UIButton]()
+    var buttonTitles: [String] = []
 
     public init (
         title: String,
         resultView: UIView,
         description: String,
-        buttons: [UIButton]
+        buttonTitles: [String]
     ) {
         super.init(frame: .zero)
         self.titleLabel.text = title
         self.resultView.addSubview(resultView)
         self.descriptionLabel.text = description
-        self.buttons = buttons
+        self.buttonTitles = buttonTitles
 
         self.attribute()
         self.layout()
@@ -112,12 +112,15 @@ public final class TTPopup: UIView, UIComponentBased {
     }
 
     public func attribute() {
-        if self.buttons.count == 1 {
-            self.leftButton = self.buttons.first ?? UIButton()
+        if self.buttonTitles.count == 1 {
+            self.leftButton.setTitleColor(.primary, for: .normal)
             self.rightButton.isHidden = true
         }
-        self.leftButton = self.buttons.first ?? UIButton()
-        self.rightButton = self.buttons.last ?? UIButton()
+        else if self.buttonTitles.count > 2 {
+            fatalError("Up to 2 buttons can be added")
+        }
+        self.leftButton.setTitle(self.buttonTitles.first, for: .normal)
+        self.rightButton.setTitle(self.buttonTitles.last, for: .normal)
 
         self.addSubviews(
             self.dimView,
@@ -155,6 +158,14 @@ public final class TTPopup: UIView, UIComponentBased {
         
         self.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+    }
+    
+    /// 배경 눌렀을 때 액션
+    @MainActor
+    public func didTapBackground(completion: (() -> Void)? = nil) {
+        self.dimView.addTapAction {
+            completion?()
         }
     }
 

--- a/TwoToo/ViewController.swift
+++ b/TwoToo/ViewController.swift
@@ -43,18 +43,22 @@ class ViewController: UIViewController {
             title: "Test",
             resultView: self.popupContentView,
             description: "테스트 입니다",
-            buttons: [self.leftButton]
+            buttonTitles: ["취소", "그만두기"]
         )
+        v.didTapBackground {
+            print("배경 클릭")
+        }
+        v.didTapLeftButton {
+            print("왼쪽 버튼 클릭")
+        }
+        v.didTapRightButton {
+            print("오른쪽 버튼 클릭")
+        }
         return v
     }()
     
     lazy var popupContentView: UIView = {
         let v = UIView()
-        return v
-    }()
-    
-    lazy var leftButton: UIButton = {
-        let v = UIButton()
         return v
     }()
     

--- a/TwoToo/ViewController.swift
+++ b/TwoToo/ViewController.swift
@@ -38,6 +38,26 @@ class ViewController: UIViewController {
         return v
     }()
     
+    lazy var popup: TTPopup = {
+        let v = TTPopup(
+            title: "Test",
+            resultView: self.popupContentView,
+            description: "테스트 입니다",
+            buttons: [self.leftButton]
+        )
+        return v
+    }()
+    
+    lazy var popupContentView: UIView = {
+        let v = UIView()
+        return v
+    }()
+    
+    lazy var leftButton: UIButton = {
+        let v = UIButton()
+        return v
+    }()
+    
     @objc func didTapShortToastTest() {
         Task { @MainActor in
             Toast.shared.makeToast("1")
@@ -59,6 +79,8 @@ class ViewController: UIViewController {
         self.stackView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+        
+        self.view.addSubview(self.popup)
     }
 }
 

--- a/TwoToo/ViewController.swift
+++ b/TwoToo/ViewController.swift
@@ -59,6 +59,19 @@ class ViewController: UIViewController {
     
     lazy var popupContentView: UIView = {
         let v = UIView()
+        v.backgroundColor = .grey200
+        return v
+    }()
+    
+    lazy var nameLabel: UILabel = {
+        let v = UILabel()
+        v.text = "내 이름"
+        return v
+    }()
+    
+    lazy var partnerLabel: UILabel = {
+        let v = UILabel()
+        v.text = "상대방 이름"
         return v
     }()
     
@@ -85,6 +98,18 @@ class ViewController: UIViewController {
         }
         
         self.view.addSubview(self.popup)
+        
+        self.popupContentView.addSubview(self.nameLabel)
+        self.popupContentView.addSubview(self.partnerLabel)
+        
+        self.nameLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(10)
+        }
+        self.partnerLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(10)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 🔥필요한것만 가져다 쓰고 안쓰는것 지우고 올리기🔥 -->

<!-- 표템플릿
|내용1|내용2|내용3|
|:---:|:---:|:---:|
|이미지1|이미지2|이미지3|
-->

<!-- 체크박스
- [ ] 체크박스1
-->

## 개요

- resultView 내에 화면 레이아웃을 못잡는 현상을 수정합니다.

## 변경사항

- 팝업뷰로 주입한 resultView 의 레이아웃을 꽉 차게 잡아줍니다.

++ 유연함을 위해 resultView 의 가로 길이를 고정값이 아닌 팝업뷰와 같은 길이로 세팅하였습니다.

## 스크린샷

![Simulator Screenshot - iPhone 14 Pro - 2023-06-23 at 11 54 48](https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/aa1e7820-4766-4878-a3a4-e9ddbf3a27f9)

[🐛 resultView 내에 화면 레이아웃을 못잡는 현상 수정](https://github.com/mash-up-kr/TwoToo_iOS/commit/3915f94f49a29b72cfe44ea79502b9c60a68630a)

