### PR TITLE
닉네임 통신 연동

### DIFF
--- a/Core/Worker/Sources/Worker/LocalWorker/InvitationLocalWorker.swift
+++ b/Core/Worker/Sources/Worker/LocalWorker/InvitationLocalWorker.swift
@@ -26,6 +26,9 @@ public final class InvitationLocalWorker: InvitationLocalWorkerProtocol {
             return self.localDataSource?.read(key: self.key)
         }
         set {
+            guard let newValue = newValue else {
+                return
+            }
             self.localDataSource?.save(value: newValue, key: self.key)
         }
     }

--- a/Core/Worker/Sources/Worker/LocalWorker/InvitedUserLocalWorker.swift
+++ b/Core/Worker/Sources/Worker/LocalWorker/InvitedUserLocalWorker.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public protocol InvitedUserLocalWorkerProtocol {
     var invitedUser: String? { get set }
+    var invitedUserNo: Int? { get set }
 }
 
 public final class InvitedUserLocalWorker: InvitedUserLocalWorkerProtocol {
@@ -19,14 +20,30 @@ public final class InvitedUserLocalWorker: InvitedUserLocalWorkerProtocol {
         self.localDataSource = localDataSource
     }
     
-    private let key: String = "invitedUser"
+    private let invitedUserKey: String = "invitedUser"
+    private let invitedUserNoKey: String = "invitedUserNo"
     
     public var invitedUser: String? {
         get {
-            return self.localDataSource?.read(key: self.key)
+            return self.localDataSource?.read(key: self.invitedUserKey)
         }
         set {
-            self.localDataSource?.save(value: newValue, key: self.key)
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.invitedUserKey)
+        }
+    }
+    
+    public var invitedUserNo: Int? {
+        get {
+            return self.localDataSource?.read(key: self.invitedUserNoKey)
+        }
+        set {
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.invitedUserNoKey)
         }
     }
 }

--- a/Core/Worker/Sources/Worker/LocalWorker/MeLocalWorker.swift
+++ b/Core/Worker/Sources/Worker/LocalWorker/MeLocalWorker.swift
@@ -10,6 +10,10 @@ import Network
 
 public protocol MeLocalWorkerProtocol {
     var token: String? { get set }
+    var userNo: Int? { get set }
+    var nickname: String? { get set }
+    var partnerNo: Int? { get set }
+    var deviceToken: String? { get set }
 }
 
 public final class MeLocalWorker: MeLocalWorkerProtocol {
@@ -21,16 +25,71 @@ public final class MeLocalWorker: MeLocalWorkerProtocol {
     }
     
     private let tokenKey: String = "token"
+    private let userNoKey: String = "userNo"
+    private let nicknameKey: String = "nickname"
+    private let partnerNoKey: String = "partnerNo"
+    private let deviceTokenKey: String = "deviceToken"
     
     public var token: String? {
         get {
             return self.localDataSource?.read(key: self.tokenKey)
         }
         set {
+            guard let newValue = newValue else {
+                return
+            }
             var networkConfiguration = NetworkConfiguration()
-            networkConfiguration.headers["bearer"] = newValue
+            networkConfiguration.headers["Authorization"] = "Bearer \(newValue)"
             NetworkManager.shared.updateConfiguration(networkConfiguration)
             self.localDataSource?.save(value: newValue, key: self.tokenKey)
+        }
+    }
+    
+    public var userNo: Int? {
+        get {
+            return self.localDataSource?.read(key: self.userNoKey)
+        }
+        set {
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.userNoKey)
+        }
+    }
+    
+    public var nickname: String? {
+        get {
+            return self.localDataSource?.read(key: self.nicknameKey)
+        }
+        set {
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.nicknameKey)
+        }
+    }
+    
+    public var partnerNo: Int? {
+        get {
+            return self.localDataSource?.read(key: self.partnerNoKey)
+        }
+        set {
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.partnerNoKey)
+        }
+    }
+    
+    public var deviceToken: String? {
+        get {
+            return self.localDataSource?.read(key: self.deviceTokenKey)
+        }
+        set {
+            guard let newValue = newValue else {
+                return
+            }
+            self.localDataSource?.save(value: newValue, key: self.deviceTokenKey)
         }
     }
 }

--- a/Core/Worker/Sources/Worker/LocalWorker/OnboardingLocalWorker.swift
+++ b/Core/Worker/Sources/Worker/LocalWorker/OnboardingLocalWorker.swift
@@ -26,6 +26,9 @@ public final class OnboardingLocalWorker: OnboardingLocalWorkerProtocol {
             return self.localDataSource?.read(key: self.key)
         }
         set {
+            guard let newValue = newValue else {
+                return
+            }
             self.localDataSource?.save(value: newValue, key: self.key)
         }
     }

--- a/Core/Worker/Sources/Worker/NetworkWorker/NicknameNetworkWorker.swift
+++ b/Core/Worker/Sources/Worker/NetworkWorker/NicknameNetworkWorker.swift
@@ -1,0 +1,40 @@
+//
+//  NicknameNetworkWorker.swift
+//  
+//
+//  Created by 박건우 on 2023/07/29.
+//
+
+import Foundation
+import Network
+
+// https://twotoo-node-zmtrd.run.goorm.site/user/nickname
+
+public struct NicknameResponse: Decodable {
+    public var userNo: Int
+    public var nickname: String
+    public var partnerNo: Int?
+}
+
+public protocol NicknameNetworkWorkerProtocol {
+    func requestNicknameRegist(nickname: String, partnerNo: Int?) async throws -> NicknameResponse
+}
+
+public final class NicknameNetworkWorker: NicknameNetworkWorkerProtocol {
+    
+    public init() {}
+    
+    public func requestNicknameRegist(nickname: String, partnerNo: Int?) async throws -> NicknameResponse {
+        var parameters: Parameters = [:]
+        if let partnerNo = partnerNo {
+            parameters["partnerNo"] = partnerNo
+        }
+        parameters["nickname"] = nickname
+        
+        return try await NetworkManager.shared.request(
+            path: "/user/nickname",
+            method: .patch,
+            parameters: parameters
+        )
+    }
+}

--- a/Scene/LoginScene/Sources/LoginScene/LoginWorker.swift
+++ b/Scene/LoginScene/Sources/LoginScene/LoginWorker.swift
@@ -78,9 +78,12 @@ final class LoginWorker: LoginWorkerProtocol {
         let authResponse = try await self.authNetworkWorker.requestAuthorize(
             socialId: socialId,
             loginType: loginType,
-            deviceToken: "Test"
+            deviceToken: self.meLocalWorker.deviceToken ?? "Test"
         )
         self.meLocalWorker.token = authResponse.accessToken
+        self.meLocalWorker.nickname = authResponse.nickname
+        self.meLocalWorker.userNo = authResponse.userNo
+        self.meLocalWorker.partnerNo = authResponse.partnerNo
         switch authResponse.loginType {
             case "NEED_NICKNAME":
                 return .nickname

--- a/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistInteractor.swift
+++ b/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistInteractor.swift
@@ -99,27 +99,17 @@ extension NicknameRegistInteractor {
 extension NicknameRegistInteractor {
     
     func didTapConfirmButton() async {
-        
         do {
-            try await self.worker.requestSetNickname(nickname: self.nickname)
+            let isMatching = try await self.worker.requestSetNicknameAndMatching(nickname: self.nickname)
+            if isMatching {
+                self.didTriggerRouteToHomeScene.send(())
+            }
+            else {
+                self.didTriggerRouteToInvitationSendScene.send(())
+            }
         }
         catch {
             await self.presenter.presentNicknameError(error: error)
-        }
-        
-        // 초대하는사람
-        if self.worker.invitedUser == nil {
-            self.didTriggerRouteToInvitationSendScene.send(())
-            return
-        }
-        
-        // 초대받는사람
-        do {
-            try await self.worker.requestMatching()
-            self.didTriggerRouteToHomeScene.send(())
-        }
-        catch {
-            await self.presenter.presentMatchingError(error: error)
         }
     }
 }

--- a/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistModels.swift
+++ b/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistModels.swift
@@ -15,6 +15,7 @@ enum NicknameRegist {
     enum Model {
         
         struct InvitedUser {
+            var no: Int
             var name: String
         }
     }

--- a/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistPresenter.swift
+++ b/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistPresenter.swift
@@ -18,8 +18,6 @@ protocol NicknameRegistPresentationLogic {
     func presentDisabledConfirmButton()
     /// 닉네임 설정 오류를 보여준다.
     func presentNicknameError(error: Error)
-    /// 매칭 오류를 보여준다.
-    func presentMatchingError(error: Error)
 }
 
 final class NicknameRegistPresenter {
@@ -48,9 +46,5 @@ extension NicknameRegistPresenter: NicknameRegistPresentationLogic {
     
     func presentNicknameError(error: Error) {
         self.viewController?.displayToast(viewModel: .init(message: "닉네임을 설정하던 중 오류가 발생하였습니다"))
-    }
-    
-    func presentMatchingError(error: Error) {
-        self.viewController?.displayToast(viewModel: .init(message: "상대방과 매칭 요청 중 오류가 발생하였습니다"))
     }
 }

--- a/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistSceneFactory.swift
+++ b/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistSceneFactory.swift
@@ -35,9 +35,16 @@ public final class NicknameRegistSceneFactory {
     public func make(with configuration: NicknameRegistConfiguration) -> NicknameRegistScene {
         let localDataSource = LocalDataSource()
         let invitedUserLocalWorker = InvitedUserLocalWorker(localDataSource: localDataSource)
+        let meLocalWorker = MeLocalWorker(localDataSource: localDataSource)
+        let nicknameNetworkWorker = NicknameNetworkWorker()
+        
         let presenter = NicknameRegistPresenter()
         let router = NicknameRegistRouter()
-        let worker = NicknameRegistWorker(invitedUserLocalWorker: invitedUserLocalWorker)
+        let worker = NicknameRegistWorker(
+            invitedUserLocalWorker: invitedUserLocalWorker,
+            meLocalWorker: meLocalWorker,
+            nicknameNetworkWorker: nicknameNetworkWorker
+        )
         let interactor = NicknameRegistInteractor(
             presenter: presenter,
             router: router,

--- a/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistWorker.swift
+++ b/Scene/NicknameRegistScene/Sources/NicknameRegistScene/NicknameRegistWorker.swift
@@ -11,37 +11,51 @@ import CoreKit
 protocol NicknameRegistWorkerProtocol {
     /// 초대 유저
     var invitedUser: NicknameRegist.Model.InvitedUser? { get }
-    /// 닉네임 설정 요청
-    func requestSetNickname(nickname: String) async throws
-    /// 매칭 요청
-    func requestMatching() async throws
+    /// 닉네임 설정 및 매칭
+    /// Return:
+    ///     - 파트너 매칭 여부
+    func requestSetNicknameAndMatching(nickname: String) async throws -> Bool
 }
 
 final class NicknameRegistWorker: NicknameRegistWorkerProtocol {
     
-    var invitedUserWorker: InvitedUserLocalWorkerProtocol
+    var invitedUserLocalWorker: InvitedUserLocalWorkerProtocol
+    var meLocalWorker: MeLocalWorkerProtocol
+    var nicknameNetworkWorker: NicknameNetworkWorkerProtocol
         
-    init(invitedUserLocalWorker: InvitedUserLocalWorkerProtocol) {
-        self.invitedUserWorker = invitedUserLocalWorker
+    init(
+        invitedUserLocalWorker: InvitedUserLocalWorkerProtocol,
+        meLocalWorker: MeLocalWorkerProtocol,
+        nicknameNetworkWorker: NicknameNetworkWorkerProtocol
+    ) {
+        self.invitedUserLocalWorker = invitedUserLocalWorker
+        self.meLocalWorker = meLocalWorker
+        self.nicknameNetworkWorker = nicknameNetworkWorker
     }
     
     var invitedUser: NicknameRegist.Model.InvitedUser? {
-        if let user: String = self.invitedUserWorker.invitedUser {
-            return NicknameRegist.Model.InvitedUser(name: user)
+        if let user: String = self.invitedUserLocalWorker.invitedUser,
+           let userNo: Int = self.invitedUserLocalWorker.invitedUserNo {
+            return NicknameRegist.Model.InvitedUser(no: userNo, name: user)
         } else {
-            print("UserDefault에 초대 받은 유저 정보가 없습니다.")
             return nil
         }
     }
     
-    // TODO: 닉네임을 설정하는 통신 필요
-    func requestSetNickname(nickname: String) async throws {
-
-    }
-    
-    
-    // TODO: 초대 유저로 매칭을 요청하는 통신 필요
-    func requestMatching() async throws {
+    func requestSetNicknameAndMatching(nickname: String) async throws -> Bool {
+        let partnerNo = self.invitedUser?.no
+        let nicknameResponse = try await self.nicknameNetworkWorker.requestNicknameRegist(
+            nickname: nickname,
+            partnerNo: partnerNo
+        )
+        self.meLocalWorker.nickname = nicknameResponse.nickname
+        self.meLocalWorker.partnerNo = nicknameResponse.partnerNo
         
+        if partnerNo == nil {
+            return false
+        }
+        else {
+            return true
+        }
     }
 }


### PR DESCRIPTION
## 개요

- 닉네임 통신을 연동합니다.

## 변경사항

- 닉네임 통신을 연동합니다
- 닉네임 및 유저 번호를 저장하도록 Me 로컬 워커를 수정합니다.

## 스크린샷

https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/43fa5bd2-8ffe-4950-953a-b2079cb90cbf


