### PR TITLE
챌린지 필수입력에서 챌린지추천, 챌린지 선택입력 화면 전환 작업

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
@@ -93,7 +93,12 @@ final public class TTTextField: UIView, UIComponentBased {
             make.height.equalTo(UIScreen.main.bounds.size.height * 0.054)
         }
     }
-    
+
+    /// textField의 값을 설정해주는 함수
+    public func setTextFieldValue(text: String) {
+        self.textField.text = text
+    }
+
     /// textField의 값을 가져오는 함수
     public func getTextFieldValue() -> String {
         return textField.text ?? ""

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
@@ -35,6 +35,12 @@ protocol ChallengeEssentialInfoInputBusinessLogic {
 protocol ChallengeEssentialInfoInputDataStore: AnyObject {
     /// 챌린지 이름 선택 트리거
     var didTriggerSelectChallengeName: PassthroughSubject<String, Never> { get }
+    /// 챌린지명
+    var nameDataSource: String? { get }
+    /// 챌린지 시작일
+    var startDateDataSource: String? { get }
+    /// 챌린지 마감일
+    var endDateDataSource: String? { get }
 }
 
 final class ChallengeEssentialInfoInputInteractor: ChallengeEssentialInfoInputDataStore, ChallengeEssentialInfoInputBusinessLogic {

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
@@ -54,8 +54,7 @@ final class ChallengeEssentialInfoInputInteractor: ChallengeEssentialInfoInputDa
     init(
         presenter: ChallengeEssentialInfoInputPresentationLogic,
         router: ChallengeEssentialInfoInputRoutingLogic,
-        worker: ChallengeEssentialInfoInputWorkerProtocol,
-        didTriggerSelectChallengeName: PassthroughSubject<String, Never>
+        worker: ChallengeEssentialInfoInputWorkerProtocol
     ) {
         self.presenter = presenter
         self.router = router

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputModels.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputModels.swift
@@ -26,6 +26,10 @@ enum ChallengeEssentialInfoInput {
             struct NextButton {
                 var isEnabled: Bool?
             }
+
+            struct Name {
+                var text: String?
+            }
         }
     }
     

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputPresenter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputPresenter.swift
@@ -15,6 +15,8 @@ protocol ChallengeEssentialInfoInputPresentationLogic {
     func presentCalendar(startDate: ChallengeEssentialInfoInput.Model.Info.StartDate, endDate: ChallengeEssentialInfoInput.Model.Info.EndDate)
     /// 다음 버튼 활성화하여 보여준다.
     func presentEnabled(nextButton: ChallengeEssentialInfoInput.Model.Info.NextButton)
+    /// 챌린지 이름을 보여준다.
+    func presentChallengeName(model: ChallengeEssentialInfoInput.Model.Info.Name)
 }
 
 final class ChallengeEssentialInfoInputPresenter {
@@ -33,5 +35,9 @@ extension ChallengeEssentialInfoInputPresenter: ChallengeEssentialInfoInputPrese
     func presentEnabled(nextButton: ChallengeEssentialInfoInput.Model.Info.NextButton) {
 
         self.viewController?.displaySetEnableNextButton(viewModel: .init(isEnabled: nextButton.isEnabled))
+    }
+
+    func presentChallengeName(model: ChallengeEssentialInfoInput.Model.Info.Name) {
+        self.viewController?.displayChallengeName(viewModel: .init(text: model.text))
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import ChallengeAdditionalInfoInputScene
+import ChallengeRecommendScene
 
 // 다음화면
 @MainActor
@@ -26,7 +27,7 @@ final class ChallengeEssentialInfoInputRouter {
 extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingLogic {
     func routeToAdditionalInfoScene() {
 
-        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init())
+        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init(didTriggerSelectChallengeName: .init()))
 
         let challengeAdditionalInfoInputViewController = challengeAdditionalInfoInputScene.viewController
 
@@ -34,6 +35,10 @@ extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingL
     }
     
     func routeToChallengeRecommendationScene() {
-        
+        guard let challengeName = self.dataStore?.didTriggerSelectChallengeName else { return }
+
+        let challengeRecommendationScene = ChallengeRecommendSceneFactory().make(with: .init(didTriggerSelectChallengeName: challengeName)).bottomSheetViewController
+
+        self.viewController?.present(challengeRecommendationScene, animated: true)
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
@@ -26,8 +26,15 @@ final class ChallengeEssentialInfoInputRouter {
 
 extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingLogic {
     func routeToAdditionalInfoScene() {
+        guard let challengeName = self.dataStore?.nameDataSource,
+              let challengeStartDate = self.dataStore?.startDateDataSource,
+              let challengeEndDate = self.dataStore?.endDateDataSource else { return }
 
-        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init(didTriggerSelectChallengeName: .init()))
+        let challengeAdditionalInfoInputScene = ChallengeAdditionalInfoInputSceneFactory().make(
+            with: .init(challengeName: challengeName,
+                        challengeStartDate: challengeStartDate,
+                        challengeEndDate: challengeEndDate)
+        )
 
         let challengeAdditionalInfoInputViewController = challengeAdditionalInfoInputScene.viewController
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
@@ -15,13 +15,7 @@ public protocol ChallengeEssentialInfoInputScene: AnyObject, Scene {
 
 public struct ChallengeEssentialInfoInputConfiguration {
 
-    var didTriggerSelectChallengeName: PassthroughSubject<String, Never>
-
-    public init(
-        didTriggerSelectChallengeName: PassthroughSubject<String, Never>
-    ) {
-        self.didTriggerSelectChallengeName = didTriggerSelectChallengeName
-    }
+    public init() {}
 }
 
 public final class ChallengeEssentialInfoInputSceneFactory {
@@ -36,8 +30,7 @@ public final class ChallengeEssentialInfoInputSceneFactory {
         let interactor = ChallengeEssentialInfoInputInteractor(
             presenter: presenter,
             router: router,
-            worker: worker,
-            didTriggerSelectChallengeName: configuration.didTriggerSelectChallengeName
+            worker: worker
         )
         let viewController = ChallengeEssentialInfoInputViewController(
             interactor: interactor

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
@@ -15,8 +15,13 @@ public protocol ChallengeEssentialInfoInputScene: AnyObject, Scene {
 
 public struct ChallengeEssentialInfoInputConfiguration {
 
-    public init() {}
+    var didTriggerSelectChallengeName: PassthroughSubject<String, Never>
 
+    public init(
+        didTriggerSelectChallengeName: PassthroughSubject<String, Never>
+    ) {
+        self.didTriggerSelectChallengeName = didTriggerSelectChallengeName
+    }
 }
 
 public final class ChallengeEssentialInfoInputSceneFactory {
@@ -31,7 +36,8 @@ public final class ChallengeEssentialInfoInputSceneFactory {
         let interactor = ChallengeEssentialInfoInputInteractor(
             presenter: presenter,
             router: router,
-            worker: worker
+            worker: worker,
+            didTriggerSelectChallengeName: configuration.didTriggerSelectChallengeName
         )
         let viewController = ChallengeEssentialInfoInputViewController(
             interactor: interactor

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -9,10 +9,15 @@
 import CoreKit
 import UIKit
 import DesignSystem
+import Util
 
 protocol ChallengeEssentialInfoInputDisplayLogic: AnyObject {
+    /// NextButton enable 한다
     func displaySetEnableNextButton(viewModel: ChallengeEssentialInfoInput.ViewModel.NextButton)
+    /// 캘린더 화면 보여준다.
     func displayCalendar(viewModel: ChallengeEssentialInfoInput.ViewModel.ChallengeDate)
+    /// 챌린지 명을 업데이트 시켜준다.
+    func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name)
 }
 
 final class ChallengeEssentialInfoInputViewController: UIViewController {
@@ -60,7 +65,11 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         v.titleLabel?.font = .body2
         v.layer.cornerRadius = 10
         v.contentEdgeInsets = .init(top: 8, left: 11, bottom: 8, right: 11)
-
+        v.addTapAction { [weak self] in
+            Task {
+                await self?.interactor.didTapChallengeRecommendationButton()
+            }
+        }
         return v
     }()
 
@@ -256,6 +265,12 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
     func displaySetEnableNextButton(viewModel: ChallengeEssentialInfoInput.ViewModel.NextButton) {
         viewModel.isEnabled.unwrap { enable in
             self.nextButton.setIsEnabled(enable)
+        }
+    }
+
+    func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name) {
+        viewModel.text.unwrap {
+            self.challengeNameTextField.setTextFieldValue(text: $0)
         }
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -20,14 +20,7 @@ protocol ChallengeEssentialInfoInputDisplayLogic: AnyObject {
     func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name)
 }
 
-final class ChallengeEssentialInfoInputViewController: UIViewController, TTNavigationDetailBarDelegate {
-    func didTapDetailLeftButton() {
-        self.navigationController?.popViewController(animated: true)
-    }
-
-    func didTapDetailRightButton() {
-
-    }
+final class ChallengeEssentialInfoInputViewController: UIViewController {
 
     var interactor: ChallengeEssentialInfoInputBusinessLogic
 
@@ -267,6 +260,16 @@ final class ChallengeEssentialInfoInputViewController: UIViewController, TTNavig
 }
 
 // MARK: - Trigger
+
+extension ChallengeEssentialInfoInputViewController: TTNavigationDetailBarDelegate {
+    func didTapDetailLeftButton() {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    func didTapDetailRightButton() {
+
+    }
+}
 
 // MARK: - Trigger by Parent Scene
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -73,13 +73,6 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         return v
     }()
 
-    private lazy var entireDateStackView: UIStackView = {
-        let v = UIStackView()
-        v.axis = .horizontal
-        v.spacing = 36
-        return v
-    }()
-
     private lazy var startDateStackView: UIStackView = {
         let v = UIStackView()
         v.spacing = 8
@@ -196,11 +189,10 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         self.view.backgroundColor = .second02
 
         self.headerStackView.addArrangedSubviews(self.processLabel, self.headerLabel, self.captionLabel)
-        self.entireDateStackView.addArrangedSubviews(self.startDateStackView, self.endDateStackView)
         self.startDateStackView.addArrangedSubviews(self.startDateLabel, self.startDatePicker)
         self.endDateStackView.addArrangedSubviews(self.endDateLabel, self.endDatePicker)
 
-        self.view.addSubviews(self.headerStackView, self.challengeNameTextField, self.challengeRecommendButton, self.entireDateStackView, self.nextButton)
+        self.view.addSubviews(self.headerStackView, self.challengeNameTextField, self.challengeRecommendButton, self.startDateStackView, self.endDateStackView, self.nextButton)
 
         self.headerStackView.setCustomSpacing(8, after: self.processLabel)
         self.headerStackView.setCustomSpacing(12, after: self.headerLabel)
@@ -221,20 +213,18 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
 
         self.challengeRecommendButton.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(24)
-            make.bottom.equalTo(self.entireDateStackView.snp.top).offset(-43)
         }
         
         self.startDateStackView.snp.makeConstraints { make in
+            make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(43)
+            make.leading.equalTo(self.challengeRecommendButton.snp.leading)
             make.width.equalTo(UIScreen.main.bounds.width * 0.27)
         }
 
         self.endDateStackView.snp.makeConstraints { make in
+            make.leading.equalTo(self.startDateStackView.snp.trailing).offset(36)
+            make.top.equalTo(self.startDateStackView.snp.top)
             make.width.equalTo(UIScreen.main.bounds.width * 0.27)
-        }
-
-        self.entireDateStackView.snp.makeConstraints { make in
-            make.leading.equalTo(self.challengeRecommendButton.snp.leading)
-            make.trailing.equalToSuperview().offset(-109)
         }
 
         self.nextButton.snp.makeConstraints { make in

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -95,6 +95,7 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         v.locale = Locale(identifier: "ko_KR")
         v.calendar.locale = Locale(identifier: "ko_KR")
         v.addTarget(self, action: #selector(didTapStartDate), for: .valueChanged)
+        v.minimumDate = Date()
         return v
     }()
 
@@ -113,6 +114,7 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         v.locale = Locale(identifier: "ko_KR")
         v.calendar.locale = Locale(identifier: "ko_KR")
         v.addTarget(self, action: #selector(didTapEndDate), for: .valueChanged)
+        v.minimumDate = Date()
         return v
     }()
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -133,6 +133,11 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
 
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
+        v.addAction {
+            Task {
+                await self.interactor.didTapNextButton()
+            }
+        }
         return v
     }()
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -20,11 +20,26 @@ protocol ChallengeEssentialInfoInputDisplayLogic: AnyObject {
     func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name)
 }
 
-final class ChallengeEssentialInfoInputViewController: UIViewController {
+final class ChallengeEssentialInfoInputViewController: UIViewController, TTNavigationDetailBarDelegate {
+    func didTapDetailLeftButton() {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    func didTapDetailRightButton() {
+
+    }
+
     var interactor: ChallengeEssentialInfoInputBusinessLogic
 
     // MARK: - UI
-    
+
+    private lazy var navigationbar: TTNavigationDetailBar = {
+        let v = TTNavigationDetailBar(title: "", leftButtonImage: .asset(.icon_back), rightButtonImage: nil)
+        v.delegate = self
+        v.delegate?.didTapDetailLeftButton()
+        return v
+    }()
+
     private lazy var headerStackView: UIStackView = {
         let v = UIStackView()
         v.axis = .vertical
@@ -194,13 +209,27 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         self.startDateStackView.addArrangedSubviews(self.startDateLabel, self.startDatePicker)
         self.endDateStackView.addArrangedSubviews(self.endDateLabel, self.endDatePicker)
 
-        self.view.addSubviews(self.headerStackView, self.challengeNameTextField, self.challengeRecommendButton, self.startDateStackView, self.endDateStackView, self.nextButton)
+        self.view.addSubviews(
+            self.navigationbar,
+            self.headerStackView,
+            self.challengeNameTextField,
+            self.challengeRecommendButton,
+            self.startDateStackView,
+            self.endDateStackView,
+            self.nextButton
+        )
 
         self.headerStackView.setCustomSpacing(8, after: self.processLabel)
         self.headerStackView.setCustomSpacing(12, after: self.headerLabel)
 
+        self.navigationbar.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(44)
+        }
+
         self.headerStackView.snp.makeConstraints { make in
-            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(2)
+            make.top.equalTo(self.navigationbar.snp.bottom).offset(2)
             make.leading.equalToSuperview().offset(24)
             make.trailing.lessThanOrEqualToSuperview().offset(-35)
             make.bottom.equalTo(self.challengeNameTextField.snp.top).offset(-19)


### PR DESCRIPTION
## 개요
- 챌린지 필수입력에서 챌린지 추천버튼으로 화면전환 및 챌린지명 입력 라우터 구현합니다.
- 챌린지 필수입력에서 챌린지 선택 입력 화면 전환 구현합니다.

## 변경사항
- 챌린지 필수입력에서 추천 버튼으로 화면전환 및 데이터 전송
- 챌린지 필수입력에서 챌린지 선택 입력 화면전환 및 데이터 전송

## 스크린샷
![PR](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/99ca5f8d-86eb-460d-a793-ec19b310664b)

