### PR TITLE
챌린지 선택입력에서 챌린지 확인으로 화면 전환 작업

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
@@ -93,7 +93,12 @@ final public class TTTextField: UIView, UIComponentBased {
             make.height.equalTo(UIScreen.main.bounds.size.height * 0.054)
         }
     }
-    
+
+    /// textField의 값을 설정해주는 함수
+    public func setTextFieldValue(text: String) {
+        self.textField.text = text
+    }
+
     /// textField의 값을 가져오는 함수
     public func getTextFieldValue() -> String {
         return textField.text ?? ""

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputInteractor.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputInteractor.swift
@@ -15,9 +15,21 @@ protocol ChallengeAdditionalInfoInputBusinessLogic {
     func didTapNextButton() async
 }
 
-protocol ChallengeAdditionalInfoInputDataStore: AnyObject {}
+protocol ChallengeAdditionalInfoInputDataStore: AnyObject {
+    /// 챌린지명
+    var nameDataSource: String? { get }
+    /// 챌린지 시작일
+    var startDateDataSource: String? { get }
+    /// 챌린지 마감일
+    var endDateDataSource: String? { get }
+    /// 챌린지 규칙
+    var additionalInfoDataSource: String? { get }
+    /// 진입점 상태
+    var didEnterStatus: String? { get }
+}
 
 final class ChallengeAdditionalInfoInputInteractor: ChallengeAdditionalInfoInputDataStore, ChallengeAdditionalInfoInputBusinessLogic {
+
     var cancellables: Set<AnyCancellable> = []
     
     var presenter: ChallengeAdditionalInfoInputPresentationLogic
@@ -27,17 +39,28 @@ final class ChallengeAdditionalInfoInputInteractor: ChallengeAdditionalInfoInput
     init(
         presenter: ChallengeAdditionalInfoInputPresentationLogic,
         router: ChallengeAdditionalInfoInputRoutingLogic,
-        worker: ChallengeAdditionalInfoInputWorkerProtocol
+        worker: ChallengeAdditionalInfoInputWorkerProtocol,
+        nameDataSource: String,
+        startDateDataSource: String,
+        endDateDataSource: String
     ) {
         self.presenter = presenter
         self.router = router
         self.worker = worker
+        self.nameDataSource = nameDataSource
+        self.startDateDataSource = startDateDataSource
+        self.endDateDataSource = endDateDataSource
     }
     
     // MARK: - DataStore
 
     /// 챌린지 추가 입력(규칙 등)  문구
     var additionalInfoDataSource: String?
+
+    var nameDataSource: String?
+    var startDateDataSource: String?
+    var endDateDataSource: String?
+    var didEnterStatus: String? = "create"
 }
 
 // MARK: - Interactive Business Logic
@@ -62,9 +85,8 @@ extension ChallengeAdditionalInfoInputInteractor {
 
 extension ChallengeAdditionalInfoInputInteractor {
 
-    // TODO: - 화면 이동 시 구현
     func didTapNextButton() async {
-
+        await self.router.routeToChallengeConfirmScene()
     }
 }
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputRouter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputRouter.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import ChallengeConfirmScene
 
 @MainActor
 protocol ChallengeAdditionalInfoInputRoutingLogic {
@@ -28,6 +29,17 @@ extension ChallengeAdditionalInfoInputRouter: ChallengeAdditionalInfoInputRoutin
     }
     
     func routeToChallengeConfirmScene() {
-        
+
+        guard let challengeName = self.dataStore?.nameDataSource,
+              let challengeStartDate = self.dataStore?.startDateDataSource,
+              let challengeEndDate = self.dataStore?.endDateDataSource,
+              let didEnterStatus = self.dataStore?.didEnterStatus
+        else { return }
+
+        let challengeConfirmScene = ChallengeConfirmSceneFactory().make(with: .init(challengeName: challengeName, challengeStartDate: challengeStartDate, challengeEndDate: challengeEndDate, challengeRule: self.dataStore?.additionalInfoDataSource, didEnterStatus: didEnterStatus))
+
+        let challengeConfirmViewController = challengeConfirmScene.viewController
+
+        self.viewController?.navigationController?.pushViewController(challengeConfirmViewController, animated: true)
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputSceneFactory.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputSceneFactory.swift
@@ -41,7 +41,10 @@ public final class ChallengeAdditionalInfoInputSceneFactory {
         let interactor = ChallengeAdditionalInfoInputInteractor(
             presenter: presenter,
             router: router,
-            worker: worker
+            worker: worker,
+            nameDataSource: configuration.challengeName,
+            startDateDataSource: configuration.challengeStartDate,
+            endDateDataSource: configuration.challengeEndDate
         )
         let viewController = ChallengeAdditionalInfoInputViewController(
             interactor: interactor

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -16,6 +16,13 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
 
     // MARK: - UI
 
+    private lazy var navigationbar: TTNavigationDetailBar = {
+        let v = TTNavigationDetailBar(title: "", leftButtonImage: .asset(.icon_back), rightButtonImage: nil)
+        v.delegate = self
+        v.delegate?.didTapDetailLeftButton()
+        return v
+    }()
+
     private lazy var headerStackView: UIStackView = {
         let v = UIStackView()
         v.axis = .vertical
@@ -93,13 +100,19 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
         self.view.backgroundColor = .second02
 
         self.headerStackView.addArrangedSubviews(self.processLabel, self.headerLabel, self.captionLabel)
-        self.view.addSubviews(self.headerStackView, self.challengeRuleTextView, self.nextButton)
+        self.view.addSubviews(self.navigationbar, self.headerStackView, self.challengeRuleTextView, self.nextButton)
 
         self.headerStackView.setCustomSpacing(8, after: self.processLabel)
         self.headerStackView.setCustomSpacing(12, after: self.headerLabel)
 
+        self.navigationbar.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(44)
+        }
+
         self.headerStackView.snp.makeConstraints { make in
-            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(2)
+            make.top.equalTo(self.navigationbar.snp.bottom).offset(2)
             make.leading.equalToSuperview().offset(24)
             make.trailing.lessThanOrEqualToSuperview().offset(-35)
             make.bottom.equalTo(self.challengeRuleTextView.snp.top).offset(-42)
@@ -122,7 +135,7 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
 
 // MARK: - Trigger
 
-extension ChallengeAdditionalInfoInputViewController: TTTextViewDelegate {
+extension ChallengeAdditionalInfoInputViewController: TTTextViewDelegate, TTNavigationDetailBarDelegate {
     func textViewDidChange(text: String) {
         Task {
             await self.interactor.didEnterChallengeAdditionalInfo(commet: text)
@@ -133,6 +146,14 @@ extension ChallengeAdditionalInfoInputViewController: TTTextViewDelegate {
         Task {
             await self.interactor.didEnterChallengeAdditionalInfo(commet: text)
         }
+    }
+
+    func didTapDetailLeftButton() {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    func didTapDetailRightButton() {
+
     }
 }
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -63,6 +63,11 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
         v.setIsEnabled(true)
+        v.addAction {
+            Task {
+                await self.interactor.didTapNextButton()
+            }
+        }
         return v
     }()
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputInteractor.swift
@@ -35,6 +35,12 @@ protocol ChallengeEssentialInfoInputBusinessLogic {
 protocol ChallengeEssentialInfoInputDataStore: AnyObject {
     /// 챌린지 이름 선택 트리거
     var didTriggerSelectChallengeName: PassthroughSubject<String, Never> { get }
+    /// 챌린지명
+    var nameDataSource: String? { get }
+    /// 챌린지 시작일
+    var startDateDataSource: String? { get }
+    /// 챌린지 마감일
+    var endDateDataSource: String? { get }
 }
 
 final class ChallengeEssentialInfoInputInteractor: ChallengeEssentialInfoInputDataStore, ChallengeEssentialInfoInputBusinessLogic {

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputModels.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputModels.swift
@@ -26,6 +26,10 @@ enum ChallengeEssentialInfoInput {
             struct NextButton {
                 var isEnabled: Bool?
             }
+
+            struct Name {
+                var text: String?
+            }
         }
     }
     

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputPresenter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputPresenter.swift
@@ -15,6 +15,8 @@ protocol ChallengeEssentialInfoInputPresentationLogic {
     func presentCalendar(startDate: ChallengeEssentialInfoInput.Model.Info.StartDate, endDate: ChallengeEssentialInfoInput.Model.Info.EndDate)
     /// 다음 버튼 활성화하여 보여준다.
     func presentEnabled(nextButton: ChallengeEssentialInfoInput.Model.Info.NextButton)
+    /// 챌린지 이름을 보여준다.
+    func presentChallengeName(model: ChallengeEssentialInfoInput.Model.Info.Name)
 }
 
 final class ChallengeEssentialInfoInputPresenter {
@@ -33,5 +35,9 @@ extension ChallengeEssentialInfoInputPresenter: ChallengeEssentialInfoInputPrese
     func presentEnabled(nextButton: ChallengeEssentialInfoInput.Model.Info.NextButton) {
 
         self.viewController?.displaySetEnableNextButton(viewModel: .init(isEnabled: nextButton.isEnabled))
+    }
+
+    func presentChallengeName(model: ChallengeEssentialInfoInput.Model.Info.Name) {
+        self.viewController?.displayChallengeName(viewModel: .init(text: model.text))
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import ChallengeAdditionalInfoInputScene
+import ChallengeRecommendScene
 
 // 다음화면
 @MainActor
@@ -26,7 +27,7 @@ final class ChallengeEssentialInfoInputRouter {
 extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingLogic {
     func routeToAdditionalInfoScene() {
 
-        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init())
+        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init(didTriggerSelectChallengeName: .init()))
 
         let challengeAdditionalInfoInputViewController = challengeAdditionalInfoInputScene.viewController
 
@@ -34,6 +35,10 @@ extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingL
     }
     
     func routeToChallengeRecommendationScene() {
-        
+        guard let challengeName = self.dataStore?.didTriggerSelectChallengeName else { return }
+
+        let challengeRecommendationScene = ChallengeRecommendSceneFactory().make(with: .init(didTriggerSelectChallengeName: challengeName)).bottomSheetViewController
+
+        self.viewController?.present(challengeRecommendationScene, animated: true)
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputRouter.swift
@@ -26,8 +26,15 @@ final class ChallengeEssentialInfoInputRouter {
 
 extension ChallengeEssentialInfoInputRouter: ChallengeEssentialInfoInputRoutingLogic {
     func routeToAdditionalInfoScene() {
+        guard let challengeName = self.dataStore?.nameDataSource,
+              let challengeStartDate = self.dataStore?.startDateDataSource,
+              let challengeEndDate = self.dataStore?.endDateDataSource else { return }
 
-        let challengeAdditionalInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init(didTriggerSelectChallengeName: .init()))
+        let challengeAdditionalInfoInputScene = ChallengeAdditionalInfoInputSceneFactory().make(
+            with: .init(challengeName: challengeName,
+                        challengeStartDate: challengeStartDate,
+                        challengeEndDate: challengeEndDate)
+        )
 
         let challengeAdditionalInfoInputViewController = challengeAdditionalInfoInputScene.viewController
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputSceneFactory.swift
@@ -15,8 +15,13 @@ public protocol ChallengeEssentialInfoInputScene: AnyObject, Scene {
 
 public struct ChallengeEssentialInfoInputConfiguration {
 
-    public init() {}
+    var didTriggerSelectChallengeName: PassthroughSubject<String, Never>
 
+    public init(
+        didTriggerSelectChallengeName: PassthroughSubject<String, Never>
+    ) {
+        self.didTriggerSelectChallengeName = didTriggerSelectChallengeName
+    }
 }
 
 public final class ChallengeEssentialInfoInputSceneFactory {
@@ -31,7 +36,8 @@ public final class ChallengeEssentialInfoInputSceneFactory {
         let interactor = ChallengeEssentialInfoInputInteractor(
             presenter: presenter,
             router: router,
-            worker: worker
+            worker: worker,
+            didTriggerSelectChallengeName: configuration.didTriggerSelectChallengeName
         )
         let viewController = ChallengeEssentialInfoInputViewController(
             interactor: interactor

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -9,10 +9,15 @@
 import CoreKit
 import UIKit
 import DesignSystem
+import Util
 
 protocol ChallengeEssentialInfoInputDisplayLogic: AnyObject {
+    /// NextButton enable 한다
     func displaySetEnableNextButton(viewModel: ChallengeEssentialInfoInput.ViewModel.NextButton)
+    /// 캘린더 화면 보여준다.
     func displayCalendar(viewModel: ChallengeEssentialInfoInput.ViewModel.ChallengeDate)
+    /// 챌린지 명을 업데이트 시켜준다.
+    func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name)
 }
 
 final class ChallengeEssentialInfoInputViewController: UIViewController {
@@ -60,7 +65,11 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         v.titleLabel?.font = .body2
         v.layer.cornerRadius = 10
         v.contentEdgeInsets = .init(top: 8, left: 11, bottom: 8, right: 11)
-
+        v.addTapAction { [weak self] in
+            Task {
+                await self?.interactor.didTapChallengeRecommendationButton()
+            }
+        }
         return v
     }()
 
@@ -256,6 +265,12 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
     func displaySetEnableNextButton(viewModel: ChallengeEssentialInfoInput.ViewModel.NextButton) {
         viewModel.isEnabled.unwrap { enable in
             self.nextButton.setIsEnabled(enable)
+        }
+    }
+
+    func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name) {
+        viewModel.text.unwrap {
+            self.challengeNameTextField.setTextFieldValue(text: $0)
         }
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -133,6 +133,11 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
 
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
+        v.addAction {
+            Task {
+                await self.interactor.didTapNextButton()
+            }
+        }
         return v
     }()
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -133,9 +133,9 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
 
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
-        v.addAction {
+        v.addAction { [weak self] in
             Task {
-                await self.interactor.didTapNextButton()
+                await self?.interactor.didTapNextButton()
             }
         }
         return v


### PR DESCRIPTION
## 개요
- 챌린지 필수입력, 선택입력의 값이 챌린지 확인 입력에 화면전환 시 보여지도록 구현합니다.

## 변경사항
- 챌린지 선택입력에서 챌린지 확인 입력으로 화면 전환 구현
- 챌린지 필수입력, 선택입력 값이 챌린지 확인 입력에 보이도록 구현

## 스크린샷
![PR2](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/4ad48f51-389d-42fb-870a-5681f47394cf)

