### PR TITLE
챌린지 필수입력, 선택입력 키보드에 따른 위치 변경

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Resources/Colors.xcassets/Grey Color/Grey_700.colorset/Contents.json
+++ b/Core/DesignSystem/Sources/DesignSystem/Resources/Colors.xcassets/Grey Color/Grey_700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.298",
+          "green" : "0.306",
+          "red" : "0.314"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.298",
+          "green" : "0.306",
+          "red" : "0.314"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Color/Pallete.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Color/Pallete.swift
@@ -27,6 +27,7 @@ public enum Pallete: String {
     case grey400 = "Grey_400"
     case grey500 = "Grey_500"
     case grey600 = "Grey_600"
+    case grey700 = "Grey_700"
     
     public static func setColor(_ pallete: Pallete) -> UIColor {
         guard let palleteColor = UIColor(named: pallete.rawValue, in: Bundle.module, compatibleWith: nil) else {

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Color/UIColor+.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Color/UIColor+.swift
@@ -56,5 +56,9 @@ extension UIColor {
     public static var grey600: UIColor {
         return Pallete.setColor(.grey600)
     }
+
+    public static var grey700: UIColor {
+        return Pallete.setColor(.grey700)
+    }
     
 }

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTTextField.swift
@@ -93,6 +93,11 @@ final public class TTTextField: UIView, UIComponentBased {
             make.height.equalTo(UIScreen.main.bounds.size.height * 0.054)
         }
     }
+    
+    @discardableResult
+    public override func becomeFirstResponder() -> Bool {
+        self.textField.becomeFirstResponder()
+    }
 
     /// textField의 값을 설정해주는 함수
     public func setTextFieldValue(text: String) {

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/Toast.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/Toast.swift
@@ -81,7 +81,7 @@ public class Toast {
     /// 토스트 컨테이너를 생성하는 함수
     private func createToastContainer() -> UIView {
         let toastContainer = UIView(frame: CGRect())
-        toastContainer.backgroundColor = .mainLightPink
+        toastContainer.backgroundColor = .grey700
         toastContainer.layer.cornerRadius = 10
         toastContainer.clipsToBounds = true
         toastContainer.alpha = 0.0
@@ -92,7 +92,7 @@ public class Toast {
     private func createToastLabel(message: String) -> UILabel {
         let toastLabel = UILabel(frame: CGRect())
         toastLabel.text = message
-        toastLabel.textColor = .primary
+        toastLabel.textColor = .mainWhite
         toastLabel.font = .body1
         toastLabel.numberOfLines = 0
         toastLabel.textAlignment = .center

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -91,6 +91,7 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
+        self.registKeyboardDelegate()
     }
     
     // MARK: - Layout
@@ -114,20 +115,19 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
             make.top.equalTo(self.navigationbar.snp.bottom).offset(2)
             make.leading.equalToSuperview().offset(24)
             make.trailing.lessThanOrEqualToSuperview().offset(-35)
-            make.bottom.equalTo(self.challengeRuleTextView.snp.top).offset(-42)
         }
 
         self.challengeRuleTextView.snp.makeConstraints { make in
+            make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
-            make.bottom.lessThanOrEqualTo(self.nextButton.snp.top).offset(-100)
             make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.77)
         }
 
         self.nextButton.snp.makeConstraints { make in
+            make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(100)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
-            make.bottom.equalToSuperview().offset(-54)
         }
     }
 }
@@ -166,4 +166,36 @@ extension ChallengeAdditionalInfoInputViewController: ChallengeAdditionalInfoInp
 
 extension ChallengeAdditionalInfoInputViewController: ChallengeAdditionalInfoInputDisplayLogic {
 
+}
+
+// MARK: - Keyboard Setting
+
+extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
+    func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
+        UIView.animate(withDuration: 0.3) {
+            self.challengeRuleTextView.snp.updateConstraints { make in
+                make.top.equalTo(self.headerStackView.snp.bottom).offset(10)
+            }
+
+            self.nextButton.snp.makeConstraints { make in
+                make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(10)
+            }
+
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    func willHideKeyboard(duration: Double) {
+        UIView.animate(withDuration: 0.3) {
+            self.challengeRuleTextView.snp.updateConstraints { make in
+                make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
+            }
+
+            self.nextButton.snp.makeConstraints { make in
+                make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(100)
+            }
+
+            self.view.layoutIfNeeded()
+        }
+    }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -125,9 +125,9 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
         }
 
         self.nextButton.snp.makeConstraints { make in
-            make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(100)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
         }
     }
 }
@@ -178,7 +178,7 @@ extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
             }
 
             self.nextButton.snp.makeConstraints { make in
-                make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(10)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 10)
             }
 
             self.view.layoutIfNeeded()
@@ -192,7 +192,7 @@ extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
             }
 
             self.nextButton.snp.makeConstraints { make in
-                make.top.lessThanOrEqualTo(self.challengeRuleTextView.snp.bottom).offset(100)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }
 
             self.view.layoutIfNeeded()

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -186,13 +186,18 @@ extension ChallengeAdditionalInfoInputViewController: ChallengeAdditionalInfoInp
 extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.makeConstraints { make in
+            self.challengeRuleTextView.snp.remakeConstraints { make in
                 make.top.equalTo(self.headerStackView.snp.bottom).offset(10)
-                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.50)
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().offset(-24)
+                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.5)
             }
 
-            self.nextButton.snp.updateConstraints { make in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(keyboardFrame.height - 10)
+            self.nextButton.snp.remakeConstraints { make in
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().offset(-24)
+                make.height.equalTo(57)
+                make.top.equalTo(self.challengeRuleTextView.snp.bottom).offset(10)
             }
 
             self.view.layoutIfNeeded()
@@ -201,12 +206,17 @@ extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
 
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.makeConstraints { make in
+            self.challengeRuleTextView.snp.remakeConstraints { make in
                 make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().offset(-24)
                 make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.77)
             }
 
-            self.nextButton.snp.updateConstraints { make in
+            self.nextButton.snp.remakeConstraints { make in
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().offset(-24)
+                make.height.equalTo(57)
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -69,9 +69,11 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
         v.setIsEnabled(true)
-        v.addAction {
+        v.addAction { [weak self] in
+            self?.didTapView()
             Task {
-                await self.interactor.didTapNextButton()
+                try await Task.sleep(nanoseconds: 100000000)
+                await self?.interactor.didTapNextButton()
             }
         }
         return v
@@ -94,10 +96,21 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
         self.registKeyboardDelegate()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.challengeRuleTextView.becomeFirstResponder()
+    }
+    
+    @objc private func didTapView() {
+        self.view.endEditing(true)
+    }
+    
     // MARK: - Layout
     
     private func setUI() {
         self.view.backgroundColor = .second02
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        self.view.addGestureRecognizer(tapGesture)
 
         self.headerStackView.addArrangedSubviews(self.processLabel, self.headerLabel, self.captionLabel)
         self.view.addSubviews(self.navigationbar, self.headerStackView, self.challengeRuleTextView, self.nextButton)

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -173,12 +173,13 @@ extension ChallengeAdditionalInfoInputViewController: ChallengeAdditionalInfoInp
 extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.updateConstraints { make in
+            self.challengeRuleTextView.snp.makeConstraints { make in
                 make.top.equalTo(self.headerStackView.snp.bottom).offset(10)
+                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.50)
             }
 
-            self.nextButton.snp.makeConstraints { make in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 10)
+            self.nextButton.snp.updateConstraints { make in
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(keyboardFrame.height - 10)
             }
 
             self.view.layoutIfNeeded()
@@ -187,11 +188,12 @@ extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
 
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.updateConstraints { make in
+            self.challengeRuleTextView.snp.makeConstraints { make in
                 make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
+                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.77)
             }
 
-            self.nextButton.snp.makeConstraints { make in
+            self.nextButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }
 

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -254,7 +254,7 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         self.nextButton.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
-            make.bottom.equalToSuperview().offset(-54)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
         }
     }
 }
@@ -309,10 +309,9 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
 extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.nextButton.snp.makeConstraints { make in
-                make.bottom.equalToSuperview().offset(-330)
+            self.nextButton.snp.updateConstraints { make in
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 10)
             }
-
             self.view.layoutIfNeeded()
         }
     }
@@ -320,9 +319,8 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
             self.nextButton.snp.makeConstraints { make in
-                make.bottom.equalToSuperview().offset(-54)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }
-
             self.view.layoutIfNeeded()
         }
     }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -309,8 +309,24 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
 extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
+
+            self.headerStackView.snp.makeConstraints { make in
+                make.bottom.equalTo(self.challengeNameTextField.snp.top)
+            }
+
+            self.challengeNameTextField.snp.updateConstraints { make in
+                make.bottom.equalTo(self.challengeRecommendButton.snp.top).offset(-10)
+            }
+            self.startDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.challengeRecommendButton.snp.bottom)
+            }
+
+            self.endDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.startDateStackView.snp.top)
+            }
+
             self.nextButton.snp.updateConstraints { make in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 10)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height + 5)
             }
             self.view.layoutIfNeeded()
         }
@@ -318,6 +334,22 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
 
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
+
+            self.headerStackView.snp.makeConstraints { make in
+                make.bottom.equalTo(self.challengeNameTextField.snp.top).offset(-19)
+            }
+
+            self.challengeNameTextField.snp.updateConstraints { make in
+                make.bottom.equalTo(self.challengeRecommendButton.snp.top).offset(-20)
+            }
+            self.startDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(43)
+            }
+
+            self.endDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.startDateStackView.snp.top)
+            }
+
             self.nextButton.snp.makeConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -323,7 +323,7 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
 
-            self.headerStackView.snp.makeConstraints { make in
+            self.headerStackView.snp.updateConstraints { make in
                 make.bottom.equalTo(self.challengeNameTextField.snp.top)
             }
 
@@ -331,7 +331,7 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
                 make.bottom.equalTo(self.challengeRecommendButton.snp.top).offset(-10)
             }
             self.startDateStackView.snp.updateConstraints { make in
-                make.top.equalTo(self.challengeRecommendButton.snp.bottom)
+                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(5)
             }
 
             self.endDateStackView.snp.updateConstraints { make in
@@ -348,7 +348,7 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
 
-            self.headerStackView.snp.makeConstraints { make in
+            self.headerStackView.snp.updateConstraints { make in
                 make.bottom.equalTo(self.challengeNameTextField.snp.top).offset(-19)
             }
 
@@ -363,7 +363,7 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
                 make.top.equalTo(self.startDateStackView.snp.top)
             }
 
-            self.nextButton.snp.makeConstraints { make in
+            self.nextButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }
             self.view.layoutIfNeeded()

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -136,7 +136,9 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
     private lazy var nextButton: TTPrimaryButtonType = {
         let v = TTPrimaryButton.create(title: "다음", .large)
         v.addAction { [weak self] in
+            self?.didTapView()
             Task {
+                try await Task.sleep(nanoseconds: 100000000)
                 await self?.interactor.didTapNextButton()
             }
         }
@@ -181,6 +183,11 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.challengeNameTextField.becomeFirstResponder()
+    }
+    
     @objc private func didTapStartDate(_ sender: UIDatePicker) {
         Task {
             await self.interactor.didTapStartDate(startDate: startDatePicker.date)
@@ -193,10 +200,16 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
         }
     }
     
+    @objc private func didTapView() {
+        self.view.endEditing(true)
+    }
+    
     // MARK: - Layout
     
     private func setUI() {
         self.view.backgroundColor = .second02
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        self.view.addGestureRecognizer(tapGesture)
 
         self.headerStackView.addArrangedSubviews(self.processLabel, self.headerLabel, self.captionLabel)
         self.startDateStackView.addArrangedSubviews(self.startDateLabel, self.startDatePicker)

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -162,6 +162,7 @@ final class ChallengeEssentialInfoInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
+        self.registKeyboardDelegate()
 
         Task {
             await self.interactor.didLoad()
@@ -299,6 +300,30 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
     func displayChallengeName(viewModel: ChallengeEssentialInfoInput.ViewModel.Name) {
         viewModel.text.unwrap {
             self.challengeNameTextField.setTextFieldValue(text: $0)
+        }
+    }
+}
+
+// MARK: - Keyboard Setting
+
+extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
+    func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
+        UIView.animate(withDuration: 0.3) {
+            self.nextButton.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().offset(-330)
+            }
+
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    func willHideKeyboard(duration: Double) {
+        UIView.animate(withDuration: 0.3) {
+            self.nextButton.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().offset(-54)
+            }
+
+            self.view.layoutIfNeeded()
         }
     }
 }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeRecommendScene/ChallengeRecommendPresenter.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeRecommendScene/ChallengeRecommendPresenter.swift
@@ -25,7 +25,7 @@ extension ChallengeRecommendPresenter: ChallengeRecommendPresentationLogic {
     
     func presentRecommendChallenges() {
         self.viewController?.displayChallenges(viewModel: .init(items: [
-            .init(title: ("💗", "사랑한다고 얘기 해주기")),
+            .init(title: ("🔥", "오늘의 갓생 인증하기")),
             .init(title: ("📝", "하루 한 문장 일상 공유하기")),
             .init(title: ("👍", "하루에 한번 칭찬 해주기")),
             .init(title: ("📷", "거울 셀카 찍기")),


### PR DESCRIPTION
## 개요
- 챌린지 필수입력, 선택입력 키보드에 따른 위치 변경을 구현합니다.
- Toast 색상 변경 및 새로운 색상 추가(Grey700)
- 챌린지 추천 문구 변경(사랑한다고 애기해주기 -> 오늘의 갓생 인증하기)

## 변경사항
- 챌린지 필수입력, 선택입력 키보드 세팅
- Toast 색상 변경 및 새로운 색상 추가
- 챌린지 추천 문구 변경

## 스크린샷

![IMG_8783](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/675fc2cc-3542-40a7-8c2c-c37dfc4492a1)

![IMG_8782](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/b4f8e439-f252-4cff-b3cb-7dc67f0aa7ad)

| PRO 버전 | SE 버전|
|:---:|:---:|
|<img src ="https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/90a0a9d5-0531-44bb-b83d-4c00d0423b43" width ="400">|<img src ="https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/136e6b81-3cc1-44a8-af44-4afe7ba0796b" width ="400">|
