### PR TITLE
히스토리 화면 네트워크 연동

### DIFF
--- a/Core/Worker/Sources/Worker/LocalWorker/HomeLocalWorker.swift
+++ b/Core/Worker/Sources/Worker/LocalWorker/HomeLocalWorker.swift
@@ -28,9 +28,7 @@ public final class HomeLocalWorker: HomeLocalWorkerProtocol {
     
     public var challengeCompletedConfirmed: Bool? {
         get {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd"
-            let currentDateString = dateFormatter.string(from: Date())
+            let currentDateString = Date().dateToString(.yearMonthDay)
             if self.lastChallengeCompletedConfirmedDateString != currentDateString {
                 self.localDataSource.save(value: false, key: self.challengeCompletedConfirmedKey)
                 return false
@@ -42,9 +40,7 @@ public final class HomeLocalWorker: HomeLocalWorkerProtocol {
                 return
             }
             if newValue {
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "yyyy-MM-dd"
-                let currentDateString = dateFormatter.string(from: Date())
+                let currentDateString = Date().dateToString(.yearMonthDay)
                 self.lastChallengeCompletedConfirmedDateString = currentDateString
             }
             self.localDataSource.save(value: newValue, key: self.challengeCompletedConfirmedKey)
@@ -53,9 +49,7 @@ public final class HomeLocalWorker: HomeLocalWorkerProtocol {
     
     public var bothCertificationConfirmed: Bool? {
         get {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd"
-            let currentDateString = dateFormatter.string(from: Date())
+            let currentDateString = Date().dateToString(.yearMonthDay)
             if self.lastBothCertificationConfirmedDateString != currentDateString {
                 self.localDataSource.save(value: false, key: self.bothCertificationConfirmedKey)
                 return false
@@ -67,9 +61,7 @@ public final class HomeLocalWorker: HomeLocalWorkerProtocol {
                 return
             }
             if newValue {
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "yyyy-MM-dd"
-                let currentDateString = dateFormatter.string(from: Date())
+                let currentDateString = Date().dateToString(.yearMonthDay)
                 self.lastBothCertificationConfirmedDateString = currentDateString
             }
             self.localDataSource.save(value: newValue, key: self.bothCertificationConfirmedKey)

--- a/Core/Worker/Sources/Worker/NetworkWorker/HistoryNetworkWorker.swift
+++ b/Core/Worker/Sources/Worker/NetworkWorker/HistoryNetworkWorker.swift
@@ -1,0 +1,59 @@
+//
+//  HistoryNetworkWorker.swift
+//  
+//
+//  Created by 박건우 on 2023/08/01.
+//
+
+import Foundation
+import Network
+
+// https://https://twotoo-node-zmtrd.run.goorm.site/challenge/histories
+
+public struct HistoryResponse: Decodable {
+    public var challengeNo: Int
+    public var name: String
+    public var description: String
+    public var startDate: String
+    public var endDate: String
+    public var user1CommitCnt: Int
+    public var user2CommitCnt: Int
+    public var user1Flower: Flower
+    public var user2Flower: Flower
+    
+    public enum Flower: String, Decodable {
+        case FIG
+        case TULIP
+        case ROSE
+        case COTTON
+        case CHRYSANTHEMUM
+        case SUNFLOWER
+        case CAMELLIA
+        case DELPHINIUM
+        
+        case none = ""
+    }
+}
+
+public protocol HistoryNetworkWorkerProtocol {
+    func requestHistoryInquiry() async throws -> [HistoryResponse]
+}
+
+public final class HistoryNetworkWorker: HistoryNetworkWorkerProtocol {
+    
+    public init() {}
+    
+    public func requestHistoryInquiry() async throws -> [HistoryResponse] {
+//        return [
+//            .init(challengeNo: 0, name: "fdafdas", description: "fdafdasfas", startDate: "2023-08-01T03:23:27.788Z", endDate: "2023-08-24T03:23:27.788Z", user1CommitCnt: 14, user2CommitCnt: 20, user1Flower: .CAMELLIA, user2Flower: .CHRYSANTHEMUM),
+//            .init(challengeNo: 1, name: "fdafdas", description: "fdafdasfas", startDate: "2023-08-01T03:23:27.788Z", endDate: "2023-08-24T03:23:27.788Z", user1CommitCnt: 0, user2CommitCnt: 10, user1Flower: .DELPHINIUM, user2Flower: .FIG),
+//            .init(challengeNo: 2, name: "fdafdas", description: "fdafdasfas", startDate: "2023-08-01T03:23:27.788Z", endDate: "2023-08-24T03:23:27.788Z", user1CommitCnt: 3, user2CommitCnt: 22, user1Flower: .CAMELLIA, user2Flower: .DELPHINIUM),
+//            .init(challengeNo: 3, name: "fdafdas", description: "fdafdasfas", startDate: "2023-08-01T03:23:27.788Z", endDate: "2023-08-24T03:23:27.788Z", user1CommitCnt: 4, user2CommitCnt: 1, user1Flower: .COTTON, user2Flower: .ROSE)
+//        ]
+//
+        return try await NetworkManager.shared.request(
+            path: "/challenge/histories",
+            method: .get
+        )
+    }
+}

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/Cell/CertificateTableViewCell.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/Cell/CertificateTableViewCell.swift
@@ -105,6 +105,8 @@ final class CertificateTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
+        self.myImageView.image = nil
+        self.partnerImageView.image = nil
         self.myCertificateID = ""
         self.partnerCertificateID = ""
         self.willCertificate = false

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
@@ -70,7 +70,7 @@ extension ChallengeHistoryPresenter {
     -> ChallengeHistory.ViewModel.Challenge {
         return .init(id: model.id,
                      name: model.name,
-                     dDayText: self.makedDayText(start: Date().dateToString(.yearMonthDay).fullStringDate(),
+                     dDayText: self.makedDayText(start: Date(),
                                                    end: model.endDate.dateToString(.yearMonthDay).fullStringDate()),
                      additionalInfo: model.additionalInfo,
                      myNickname: model.myInfo.nickname,

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryInteractor.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryInteractor.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 protocol HistoryBusinessLogic {
-    /// 첫 진입
-    func didLoad() async
+    /// 진입
+    func didAppear() async
     /// 챌린지 히스토리 클릭
     func didTapChallengeHistory(index: Int) async
     /// 설명서 클릭
@@ -53,7 +53,7 @@ extension HistoryInteractor {
 
 // MARK: Feature (진입)
 extension HistoryInteractor {
-    func didLoad() async {
+    func didAppear() async {
         do {
             let challengeList = try await self.worker.fetchChallengeList()
             self.challengeList = challengeList

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryModels.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryModels.swift
@@ -30,36 +30,9 @@ enum History {
             /// 종료일
             var endDate: Date
             /// 내 정보
-            var myInfo: User
+            var myFlower: Flower?
             /// 상대방 정보
-            var partnerInfo: User
-        }
-        
-        struct User: Equatable {
-            /// 유저 ID
-            var id: String
-            /// 닉네임
-            var nickname: String
-            /// 꽃 이름
-            var flower: Flower
-            /// 챌린지 추가 정보 문구
-            var additionalInfo: String?
-            /// 인증 리스트
-            var certificates: [Certificate]
-        }
-        
-        /// 인증
-        struct Certificate: Equatable {
-            /// 인증 ID
-            var id: String
-            /// 인증 사진
-            var certificateImageUrl: String
-            /// 인증 소감
-            var certificateComment: String
-            /// 입력 시간
-            var certificateTime: Date
-            /// 칭찬 문구
-            var complimentComment: String?
+            var partnerFlower: Flower?
         }
         
         struct ErrorToast {
@@ -81,9 +54,9 @@ enum History {
             /// 챌린지 날짜 정보 텍스트
             var dateText: String
             /// 상대 꽃 이미지
-            var partnerFlowerImage: UIImage
+            var partnerFlowerImage: UIImage?
             /// 내 꽃 이미지
-            var myFlowerImage: UIImage
+            var myFlowerImage: UIImage?
         }
         
         struct Toast {

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryPresenter.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryPresenter.swift
@@ -50,8 +50,14 @@ private extension HistoryPresenter {
             let start: String = $0.startDate.dateToString(.shortYearMonthDay)
             let end: String = $0.endDate.dateToString(.shortYearMonthDay)
             let dateText: String = start + " ~ " + end
-            let partnerFlower = FlowerMappingWorker(flowerType: $0.partnerInfo.flower).getSmallImage()
-            let myFlower = FlowerMappingWorker(flowerType: $0.myInfo.flower).getSmallImage()
+            var partnerFlower: UIImage?
+            if let partnerInfoFlower = $0.partnerFlower {
+                partnerFlower = FlowerMappingWorker(flowerType: partnerInfoFlower).getSmallImage()
+            }
+            var myFlower: UIImage?
+            if let myInfoFlower = $0.myFlower {
+                myFlower = FlowerMappingWorker(flowerType: myInfoFlower).getSmallImage()
+            }
             let cellInfo = History.ViewModel.CellInfo(orderText: "\($0.order)번째 챌린지",
                                                       nameText: $0.name,
                                                       dateText: dateText,

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryRouter.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryRouter.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import ChallengeHistoryScene
+import SafariServices
 import WebKit
 
 @MainActor
@@ -25,11 +26,21 @@ final class HistoryRouter {
 
 extension HistoryRouter: HistoryRoutingLogic {
     func routeToChallengeHistoryScene(model: History.Model.Challenge) {
-        // TODO: - ChallengeHistoryScene
+        let challengeHistoryScene = ChallengeHistorySceneFactory().make(
+            with: .init(challengeID: model.id)
+        )
+        let challengeHistoryViewController = challengeHistoryScene.viewController
+        challengeHistoryViewController.hidesBottomBarWhenPushed = true
+        self.viewController?.navigationController?.pushViewController(challengeHistoryViewController, animated: true)
     }
     
     func routeToManualScene() {
-        // TODO: - WebView
+        guard let url = URL(string: "https://two2too2.github.io/") else {
+            return
+        }
+        let safariViewController = SFSafariViewController(url: url)
+        
+        self.viewController?.present(safariViewController, animated: true, completion: nil)
     }
     
 }

--- a/Scene/HistoryScene/Sources/HistoryScene/HistorySceneFactory.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistorySceneFactory.swift
@@ -26,9 +26,13 @@ public final class HistorySceneFactory {
     
     public func make(with configuration: HistoryConfiguration) -> HistoryScene {
         
+        let localDataSource = LocalDataSource()
+        let meLocalWorker = MeLocalWorker(localDataSource: localDataSource)
+        let historyNetworkWorker = HistoryNetworkWorker()
+        
         let presenter = HistoryPresenter()
         let router = HistoryRouter()
-        let worker = HistoryWorker()
+        let worker = HistoryWorker(meLocalWorker: meLocalWorker, historyNetworkWorker: historyNetworkWorker)
         let interactor = HistoryInteractor(
             presenter: presenter,
             router: router,

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
@@ -29,17 +29,11 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
     
     // MARK: - UI
     lazy var navigationBar: TTNavigationBar = {
-        let v = TTNavigationBar(title: "우리의 정원",
+        let v = TTNavigationBar(title: "우리의 히스토리",
                                 rightButtonImage: .asset(.icon_info))
         v.delegate = self
         return v
     }()
-    
-    func didTapRightButton() {
-        Task {
-            await self.interactor.didTapManualButton()
-        }
-    }
     
     lazy var historyCollectionView: UICollectionView = {
         let layout = generateCollectionViewLayout()
@@ -66,11 +60,16 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
         super.viewDidLoad()
         self.setUI()
         self.setAttribute()
-        Task {
-            await self.interactor.didLoad()
-        }
         
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        Task {
+            await self.interactor.didAppear()
+        }
     }
     
     // MARK: - Layout
@@ -83,7 +82,7 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
         let guide = self.view.safeAreaLayoutGuide
         
         self.navigationBar.snp.makeConstraints { make in
-            make.top.equalTo(guide.snp.top).offset(13)
+            make.top.equalTo(guide.snp.top)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(44)
         }
@@ -96,7 +95,7 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
         }
         
         self.historyEmptyView.snp.makeConstraints { make in
-            make.top.equalTo(guide.snp.top)
+            make.top.equalTo(self.navigationBar.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
     }
@@ -122,6 +121,15 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
 
 // MARK: - Trigger
 
+extension HistoryViewController {
+    
+    func didTapRightButton() {
+        Task {
+            await self.interactor.didTapManualButton()
+        }
+    }
+}
+
 // MARK: - Trigger by Parent Scene
 
 extension HistoryViewController: HistoryScene {
@@ -137,7 +145,6 @@ extension HistoryViewController: HistoryDisplayLogic {
     }
     
     func displayChallengeEmptyView() {
-        self.navigationBar.isHidden = true
         self.historyCollectionView.isHidden = true
         self.historyEmptyView.isHidden = false
     }
@@ -151,13 +158,8 @@ extension HistoryViewController: HistoryDisplayLogic {
 
 extension HistoryViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if let cell = collectionView.cellForItem(at: indexPath) {
-            cell.layer.borderColor = UIColor.mainPink.cgColor
-            cell.layer.borderWidth = 3
-            cell.layer.cornerRadius = 20
-            Task {
-                await self.interactor.didTapChallengeHistory(index: indexPath.row)
-            }
+        Task {
+            await self.interactor.didTapChallengeHistory(index: indexPath.row)
         }
     }
 }

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryWorker.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryWorker.swift
@@ -14,7 +14,61 @@ protocol HistoryWorkerProtocol {
 
 final class HistoryWorker: HistoryWorkerProtocol {
     
+    var meLocalWorker: MeLocalWorkerProtocol
+    var historyNetworkWorker: HistoryNetworkWorkerProtocol
+    
+    init(
+        meLocalWorker: MeLocalWorkerProtocol,
+        historyNetworkWorker: HistoryNetworkWorkerProtocol
+    ) {
+        self.meLocalWorker = meLocalWorker
+        self.historyNetworkWorker = historyNetworkWorker
+    }
+    
     func fetchChallengeList() async throws -> History.Model.ChallengeList {
-        return []
+        let historyResponse = try await self.historyNetworkWorker.requestHistoryInquiry()
+        
+        return historyResponse.enumerated().map({ index, history in
+            return .init(
+                id: String(history.challengeNo),
+                order: index + 1,
+                name: history.name,
+                startDate: history.startDate.fullStringDate(.iso),
+                endDate: history.endDate.fullStringDate(.iso),
+                myFlower: history.user2CommitCnt < 17 ? nil : self.mapFlowerType(from: history.user2Flower),
+                partnerFlower: history.user1CommitCnt < 17 ? nil : self.mapFlowerType(from: history.user1Flower)
+            )
+        }).reversed()
+    }
+    
+    private func mapFlowerType(from flower: HistoryResponse.Flower) -> Flower? {
+        switch flower {
+            case .FIG:
+                return .fig
+                
+            case .TULIP:
+                return .tulip
+                
+            case .ROSE:
+                return .rose
+                
+            case .COTTON:
+                return .cotton
+                
+            case .CHRYSANTHEMUM:
+                return .chrysanthemum
+                
+            case .SUNFLOWER:
+                return .sunflower
+                
+            case .CAMELLIA:
+                return .camellia
+                
+            case .DELPHINIUM:
+                return .delphinium
+                
+            case .none:
+                return nil
+        }
     }
 }

--- a/Scene/HomeScene/Sources/HomeScene/HomeWorker.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeWorker.swift
@@ -99,10 +99,8 @@ final class HomeWorker: HomeWorkerProtocol {
             )
         }
         
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        let startDate = homeResponse.onGoingChallenge.flatMap { dateFormatter.date(from: $0.startDate) }
-        let endDate = homeResponse.onGoingChallenge.flatMap { dateFormatter.date(from: $0.endDate) }
+        let startDate = homeResponse.onGoingChallenge?.startDate.fullStringDate(.iso)
+        let endDate = homeResponse.onGoingChallenge?.endDate.fullStringDate(.iso)
         
         self.meLocalWorker.userNo = homeResponse.myInfo.userNo
         self.meLocalWorker.nickname = homeResponse.myInfo.nickname


### PR DESCRIPTION
## 개요

- 히스토리 화면의 네트워크를 연동합니다.

## 변경사항

- 히스토리 화면의 네트워크를 연동합니다.
- 히스토리 화면의 나머지 부분을 일괄 작업합니다.

## 스크린샷

https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/9d22ff04-8833-4231-b2b6-2ad7928a2d2c

