### PR TITLE
네비게이션 타이틀 이미지 로고 변경

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/NavigationBar/TTNavigationBar.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/NavigationBar/TTNavigationBar.swift
@@ -87,7 +87,7 @@ public final class TTNavigationBar: UIView {
         
         self.logoImageView.snp.makeConstraints { make in
             make.width.equalTo(93)
-            make.height.equalTo(13)
+            make.height.equalTo(16)
             make.leading.equalToSuperview().offset(self.containerLeadingTrailingInset)
             make.centerY.equalToSuperview()
         }


### PR DESCRIPTION
## 개요
네비게이션 타이틀 텍스트에서 이미지 로고로 변경합니다.
## 스크린샷
|Before|After|
|:---:|:---:|
|이미지1|이미지2|
|<img width="446" alt="스크린샷 2023-08-02 오후 10 20 43" src="https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/a84dbe84-34c2-421c-b142-159755143efe">|<img width="432" alt="스크린샷 2023-08-02 오후 10 21 11" src="https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/f45b65cc-a7cb-4389-b448-61bc1e1e4e73">|
