### PR TITLE
디자인 1차 QA 작업

### DIFF
--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -35,7 +35,7 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
         ChallengeHistoryDetail.ViewModel.Compliment)
     {
         let dateText = model.certificateTime.dateToString(.hangleYearMonthDay)
-        let timeText = "입력 시간  " + model.certificateTime.dateToString(.hourMinute)
+        let timeText = "인증 시간  " + model.certificateTime.dateToString(.hourMinute)
         let title = "\(model.myNickname)의 기록"
         let certification = ChallengeHistoryDetail.ViewModel.Challenge(challengeName: model.challengeName,
                                                                        certificationDateText: dateText,

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -108,7 +108,7 @@ final class ChallengeHistoryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
-        self.view.backgroundColor = .second01
+        self.view.setBackgroundDefault()
         Task {
             await self.interactor.didLoad()
         }

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
@@ -56,8 +56,9 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
     lazy var historyEmptyLabel: UILabel = {
         let v = UILabel()
         v.textColor = .grey500
-        v.font = .body1
+        v.font = .h3
         v.text = "챌린지를 완료해\n히스토리를 만들어보세요 :)"
+        v.setLineSpacing(10)
         v.textAlignment = .center
         v.numberOfLines = 0
         return v

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
@@ -71,10 +71,10 @@ final class ChallengeCompletedView: UIView {
                          self.confirmButton)
                 
         self.topChallengeInfoView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(11)
+            make.top.equalToSuperview()
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalToSuperview().multipliedBy(0.113)
+            make.height.equalToSuperview().multipliedBy(0.14)
         }
         
         self.progressBar.snp.makeConstraints { make in
@@ -93,12 +93,12 @@ final class ChallengeCompletedView: UIView {
         
         self.partnerFlowerView.snp.makeConstraints { make in
             make.centerX.equalToSuperview().multipliedBy(0.5)
-            make.bottom.equalToSuperview().multipliedBy(0.8)
+            make.bottom.equalToSuperview().multipliedBy(0.75)
             make.width.equalToSuperview().dividedBy(2)
         }
 
         self.myFlowerView.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().multipliedBy(0.8)
+            make.bottom.equalToSuperview().multipliedBy(0.75)
             make.centerX.equalToSuperview().multipliedBy(1.5)
             make.width.equalToSuperview().dividedBy(2)
         }

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
@@ -94,10 +94,10 @@ final class ChallengeInProgressView: UIView {
                          self.nudgeTitleLabel)
                 
         self.topChallengeInfoView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(11)
+            make.top.equalToSuperview()
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalToSuperview().multipliedBy(0.113)
+            make.height.equalToSuperview().multipliedBy(0.14)
         }
         
         self.progressBar.snp.makeConstraints { make in
@@ -115,13 +115,13 @@ final class ChallengeInProgressView: UIView {
         }
         
         self.partnerFlowerView.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().multipliedBy(0.8)
+            make.bottom.equalToSuperview().multipliedBy(0.75)
             make.centerX.equalToSuperview().multipliedBy(0.5)
             make.width.equalToSuperview().dividedBy(2)
         }
         
         self.myFlowerView.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().multipliedBy(0.8)
+            make.bottom.equalToSuperview().multipliedBy(0.75)
             make.centerX.equalToSuperview().multipliedBy(1.5)
             make.width.equalToSuperview().dividedBy(2)
         }

--- a/Scene/HomeScene/Sources/HomeScene/Views/Flower/Component/InduceCertificationView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Flower/Component/InduceCertificationView.swift
@@ -33,6 +33,11 @@ final class InduceCertificationView: UIStackView {
                                  self.certificatedLottieView)
         
         self.certificatedLottieView.play()
+        
+        self.certificatedLottieView.snp.makeConstraints { make in
+            make.width.equalTo(75)
+            make.height.equalTo(70)
+        }
     }
     
     required init(coder: NSCoder) {

--- a/Scene/HomeScene/Sources/HomeScene/Views/Flower/MyFlowerView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Flower/MyFlowerView.swift
@@ -80,7 +80,7 @@ final class MyFlowerView: UIView {
     lazy var nicknameView: TTTagView = {
         let v = TTTagView(textColor: .mainCoral,
                           fontSize: .body2,
-                          cornerRadius: 15)
+                          cornerRadius: 13)
         return v
     }()
     // MARK: - Method
@@ -110,6 +110,8 @@ final class MyFlowerView: UIView {
         self.emptySpeechBubbleImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.centerX.equalTo(self.flowerImageView.snp.centerX)
+            make.width.equalToSuperview().multipliedBy(0.7)
+            make.height.equalTo(62)
             make.bottom.equalTo(self.flowerImageView.snp.top).offset(-32)
         }
         


### PR DESCRIPTION
## 개요
디자인 이슈 나온 부분들을 수정했습니다.
## 변경사항
- 칭찬 문구 작성하기 아이콘 크기를 고정합니다.
- 홈 화면 `상단 챌린지 정보` 높이를 늘렸습니다.
- `꽃` 위치를 약간 위로 수정합니다.
- 챌린지 히스토리 상세 배경 디자인 시안으로 수정합니다.
- 히스토리 EmptyView 라벨 크기를 변경합니다.

## 스크린샷
|1|2|3|
|:---:|:---:|:---:|
|![Simulator Screenshot - iPhone 14 - 2023-08-05 at 15 46 06](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/e7b0366a-721f-4ac7-938d-f4c8a009fbb6)|![Simulator Screenshot - iPhone 14 - 2023-08-05 at 16 25 43](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/94886dde-d924-4edb-a159-cf9c7be17df2)|![image](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/e9d02f6b-6b1c-4cdd-9ba1-4bdc9dd27db1)|

