### PR TITLE
긴 챌린지 이름 짤리는 버그 해결

### DIFF
--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryViewController.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryViewController.swift
@@ -51,6 +51,8 @@ final class ChallengeHistoryViewController: UIViewController, UITableViewDataSou
     private let titleLabel: UILabel = {
         let v = UILabel()
         v.textColor = .primary
+        v.numberOfLines = 2
+        v.lineBreakMode = .byTruncatingTail
         v.font = .h2
         return v
     }()

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
@@ -74,7 +74,6 @@ final class ChallengeCompletedView: UIView {
             make.top.equalToSuperview().offset(11)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalToSuperview().multipliedBy(0.113)
         }
         
         self.progressBar.snp.makeConstraints { make in

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
@@ -97,7 +97,6 @@ final class ChallengeInProgressView: UIView {
             make.top.equalToSuperview().offset(11)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalToSuperview().multipliedBy(0.113)
         }
         
         self.progressBar.snp.makeConstraints { make in

--- a/Scene/HomeScene/Sources/HomeScene/Views/Common/TopChallengeInfoView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Common/TopChallengeInfoView.swift
@@ -13,6 +13,7 @@ final class TopChallengeInfoView: UIView {
         let v = UILabel()
         v.textColor = .mainCoral
         v.font = .h1
+        v.numberOfLines = 2
         v.textAlignment = .center
         v.lineBreakMode = .byTruncatingTail
         return v
@@ -39,13 +40,15 @@ final class TopChallengeInfoView: UIView {
         self.addSubviews(self.titleLabel, self.dateTagView)
         
         self.titleLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().multipliedBy(0.6)
+            make.top.equalToSuperview().offset(16)
+            make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(20)
         }
         
         self.dateTagView.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(8)
             make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview().multipliedBy(1.4)
+            make.bottom.equalToSuperview().offset(-16)
         }
     }
     

--- a/Scene/HomeScene/Sources/HomeScene/Views/Flower/Component/InduceCertificationView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Flower/Component/InduceCertificationView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import Lottie
 
-final class InduceCertificationView: UIStackView {
+final class InduceCertificationView: UIView {
     
     lazy var titleLabel: UILabel = {
         let v = UILabel()
@@ -24,18 +24,31 @@ final class InduceCertificationView: UIStackView {
         return v
     }()
     
-    init() {
-        super.init(frame: .zero)
-        self.axis = .vertical
-        self.spacing = 10
-        self.alignment = .center
-        self.addArrangedSubviews(self.titleLabel,
-                                 self.certificatedLottieView)
-        
-        self.certificatedLottieView.play()
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.layout()
     }
     
-    required init(coder: NSCoder) {
+    private func layout() {
+        self.addSubviews(self.titleLabel,
+                         self.certificatedLottieView)
+        
+        self.certificatedLottieView.play()
+        
+        self.titleLabel.snp.makeConstraints { make in
+            make.top.centerX.equalToSuperview()
+            make.height.equalTo(16)
+        }
+        
+        self.certificatedLottieView.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(10)
+            make.width.equalTo(75)
+            make.height.equalTo(70)
+            make.centerX.bottom.equalToSuperview()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     


### PR DESCRIPTION
## 개요
긴 챌린지 이름 짤리는 버그 해결합니다.
## 변경사항
- 홈 화면 및 챌린지 히스토리 최대 라인을 2로 수정합니다.
- 인증 물뿌리개 로띠 크기를 고정합니다.
## 스크린샷
|1|2|
|:---:|:---:|
|![IMG_6022](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/6fa737c7-5c02-4a47-af69-338277910525)|![IMG_6023](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/601c26c2-13b6-4b9a-868b-35958c2aec56)|

