### PR TITLE
챌린지 삭제 오류 수정

### DIFF
--- a/Core/Worker/Sources/Worker/NetworkWorker/ChallengeQuitNetworkWorker.swift
+++ b/Core/Worker/Sources/Worker/NetworkWorker/ChallengeQuitNetworkWorker.swift
@@ -24,7 +24,7 @@ public final class ChallengeQuitNetworkWorker: ChallengeQuitNetworkWorkerProtoco
     
     public func requestChallengeQuit(challengeNo: Int) async throws -> ChallengeQuitResponse {
         return try await NetworkManager.shared.request(
-            path: "challenge/\(challengeNo)",
+            path: "/challenge/\(challengeNo)",
             method: .delete
         )
     }


### PR DESCRIPTION
## 개요

- 챌린지 삭제 시 타임아웃이 나는 현상

## 변경사항

- 챌린지 삭제 path 를 잘못 넣어주어 발생하였습니다.
- 해당 문제를 수정하였습니다.

