### PR TITLE
인증 물뿌리개 터치가 안되는 현상 수정

### DIFF
--- a/Scene/HomeScene/Sources/HomeScene/Views/Flower/MyFlowerView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Flower/MyFlowerView.swift
@@ -117,6 +117,7 @@ final class MyFlowerView: UIView {
         
         self.induceCertificationView.snp.makeConstraints { make in
             make.top.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview().multipliedBy(0.8)
             make.bottom.equalTo(self.flowerImageView.snp.top).offset(-8)
         }


### PR DESCRIPTION
<!-- 🔥필요한것만 가져다 쓰고 안쓰는것 지우고 올리기🔥 -->

<!-- 표템플릿
|내용1|내용2|내용3|
|:---:|:---:|:---:|
|이미지1|이미지2|이미지3|
-->

<!-- 체크박스
- [ ] 체크박스1
-->

## 개요

- 인증 물뿌리개 터치가 안되는 현상

## 변경사항

- 인증 물뿌리개 터치가 안되는 현상
### 원인
- 뷰의 width 가 잡히지 않으며 영역이 존재하지 않았음

### 수정
- 뷰의 leading trailing 을 잡아주면 width 가 잡히도록 수정

## 스크린샷
|기존|변경 후|
|:---:|:---:|
|<img width="200" alt="스크린샷 2023-08-07 오전 11 14 28" src="https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/f1f59350-0db1-4c37-a74e-863f36eaef9c">|<img width="215" alt="스크린샷 2023-08-07 오전 11 16 22" src="https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/b086fe3d-e642-4484-8c92-27849931f1d4">|

