### PR TITLE
바텀시트 높이 및 레이아웃 재조정

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/Layout/SelfSizingScrollView.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/Layout/SelfSizingScrollView.swift
@@ -8,15 +8,29 @@
 import UIKit
 
 public final class SelfSizingScrollView: UIScrollView {
+    private var maxHeight: CGFloat = UIScreen.main.bounds.height * 0.67
     
     public override var intrinsicContentSize: CGSize {
         CGSize(width: contentSize.width,
-               height: UIScreen.main.bounds.height * 0.75)
+               height: maxHeight)
     }
 
     public override func layoutSubviews() {
         super.layoutSubviews()
         invalidateIntrinsicContentSize()
+    }
+    
+    public convenience init(maxHeight: CGFloat) {
+        self.init()
+        self.maxHeight = maxHeight
+    }
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+ 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
 }

--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/TTBottomSheetViewController.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/TTBottomSheetViewController.swift
@@ -49,8 +49,8 @@ final public class TTBottomSheetViewController: FloatingPanelController {
         surfaceView.grabberHandle.isHidden = false
         surfaceView.grabberHandle.backgroundColor = .grey400
         surfaceView.grabberHandleSize = .init(width: 39, height: 5)
+        surfaceView.grabberHandlePadding = 20
         surfaceView.appearance = appearence
-        // TODO: grabberHandle 위치 약간 내리기
     }
     
     private func setUpBackDropView(_ backDropView: BackdropView) {

--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
@@ -102,7 +102,7 @@ final class ChallengeCertificateViewController: UIViewController, BottomSheetVie
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let v = SelfSizingScrollView()
+        let v = SelfSizingScrollView(maxHeight: UIScreen.main.bounds.height * 0.72)
         v.delegate = self
         v.addTapAction { [weak self] in
             self?.view.endEditing(true)

--- a/Scene/NudgeSendScene/Sources/NudgeSendScene/NudgeSendViewController.swift
+++ b/Scene/NudgeSendScene/Sources/NudgeSendScene/NudgeSendViewController.swift
@@ -71,9 +71,6 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
     private lazy var backScrollView: UIScrollView = {
         let v = SelfSizingScrollView()
         v.addSubview(self.scrollSizeFitView)
-        v.addTapAction { [weak self] in
-            self?.view.endEditing(true)
-        }
         return v
     }()
     
@@ -82,7 +79,7 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
-        
+        self.messageTextView.becomeFirstResponder()
         Task {
             await self.interactor.didLoad()
         }
@@ -102,7 +99,7 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
         self.view.addSubview(self.backScrollView)
         
         self.titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(30)
+            make.top.equalToSuperview().offset(46)
             make.centerX.equalToSuperview()
         }
         
@@ -114,13 +111,13 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
         }
 
         self.pushButton.snp.makeConstraints { make in
-            make.top.equalTo(self.messageTextView.snp.bottom).offset(44)
+            make.top.equalTo(self.messageTextView.snp.bottom).offset(64)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
             make.height.equalTo(57)
             make.bottom.equalToSuperview()
         }
-        
+                
         self.scrollSizeFitView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.bottom.equalToSuperview()
@@ -154,7 +151,6 @@ extension NudgeSendViewController: NudgeSendScene {
 }
 
 // MARK: - Display Logic
-
 extension NudgeSendViewController: NudgeSendDisplayLogic {
     
     func displayTitle(viewModel: NudgeSend.ViewModel.Title) {

--- a/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
+++ b/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
@@ -89,6 +89,7 @@ final class PraiseSendViewController: UIViewController, BottomSheetViewControlle
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
+        self.messageTextView.becomeFirstResponder()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -115,12 +116,17 @@ final class PraiseSendViewController: UIViewController, BottomSheetViewControlle
             make.trailing.equalToSuperview().inset(24)
             make.height.equalTo(85)
         }
-
-        self.pushButton.snp.makeConstraints { make in
-            make.top.equalTo(self.messageTextView.snp.bottom).offset(44)
+        
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.messageTextView.snp.bottom).offset(14)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalTo(57)
+        }
+
+        self.pushButton.snp.makeConstraints { make in
+            make.top.equalTo(self.descriptionLabel.snp.bottom).offset(30)
+            make.leading.equalToSuperview().offset(24)
+            make.trailing.equalToSuperview().inset(24)
             make.bottom.equalToSuperview()
         }
 

--- a/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
+++ b/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
@@ -78,9 +78,6 @@ final class PraiseSendViewController: UIViewController, BottomSheetViewControlle
     private lazy var backScrollView: UIScrollView = {
         let v = SelfSizingScrollView()
         v.addSubview(self.scrollSizeFitView)
-        v.addTapAction { [weak self] in
-            self?.view.endEditing(true)
-        }
         return v
     }()
     


### PR DESCRIPTION
## 개요
바텀시트 높이 및 레이아웃 수정합니다.
## 변경사항
- 바텀시트 최대 높이 입력받게 변경합니다.
- grabberHandle 위치 아래로 약간 내렸습니다.
- 바텀시트 올라가자마자 TextView로 포커스되며 키보드를 올립니다.
- 칭찬하기 및 찌르기는 키보드를 올린 상태로 고정합니다.
## 스크린샷
|1|2|
|:--:|:--:|
|![IMG_6071](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/359544fc-e5ee-49ba-aa04-064cb69c06cb)|![IMG_6070](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/bb909e45-35b0-45a9-8a62-f38d86f523ac)|
