### PR TITLE
키보드 활성화 시 컴포넌트 레이아웃 수정

### DIFF
--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -186,40 +186,26 @@ extension ChallengeAdditionalInfoInputViewController: ChallengeAdditionalInfoInp
 extension ChallengeAdditionalInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.remakeConstraints { make in
-                make.top.equalTo(self.headerStackView.snp.bottom).offset(10)
-                make.leading.equalToSuperview().offset(24)
-                make.trailing.equalToSuperview().offset(-24)
-                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.5)
+            self.challengeRuleTextView.snp.updateConstraints { make in
+                make.top.equalTo(self.headerStackView.snp.bottom).offset(20)
             }
-
-            self.nextButton.snp.remakeConstraints { make in
-                make.leading.equalToSuperview().offset(24)
-                make.trailing.equalToSuperview().offset(-24)
-                make.height.equalTo(57)
-                make.top.equalTo(self.challengeRuleTextView.snp.bottom).offset(10)
+            
+            self.nextButton.snp.updateConstraints { make in
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(keyboardFrame.height - 20)
             }
-
             self.view.layoutIfNeeded()
         }
     }
 
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
-            self.challengeRuleTextView.snp.remakeConstraints { make in
+            self.challengeRuleTextView.snp.updateConstraints { make in
                 make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
-                make.leading.equalToSuperview().offset(24)
-                make.trailing.equalToSuperview().offset(-24)
-                make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.77)
             }
-
-            self.nextButton.snp.remakeConstraints { make in
-                make.leading.equalToSuperview().offset(24)
-                make.trailing.equalToSuperview().offset(-24)
-                make.height.equalTo(57)
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
+            
+            self.nextButton.snp.updateConstraints { make in
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide)
             }
-
             self.view.layoutIfNeeded()
         }
     }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeAdditionalInfoInputScene/ChallengeAdditionalInfoInputViewController.swift
@@ -134,7 +134,7 @@ final class ChallengeAdditionalInfoInputViewController: UIViewController {
             make.top.equalTo(self.headerStackView.snp.bottom).offset(42)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
-            make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.77)
+            make.height.equalTo(self.challengeRuleTextView.snp.width).multipliedBy(0.7)
         }
 
         self.nextButton.snp.makeConstraints { make in

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -317,25 +317,10 @@ extension ChallengeEssentialInfoInputViewController: ChallengeEssentialInfoInput
 
 extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
+        
         UIView.animate(withDuration: 0.3) {
-
-            self.headerStackView.snp.updateConstraints { make in
-                make.bottom.equalTo(self.challengeNameTextField.snp.top)
-            }
-
-            self.challengeNameTextField.snp.updateConstraints { make in
-                make.bottom.equalTo(self.challengeRecommendButton.snp.top).offset(-10)
-            }
-            self.startDateStackView.snp.updateConstraints { make in
-                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(5)
-            }
-
-            self.endDateStackView.snp.updateConstraints { make in
-                make.top.equalTo(self.startDateStackView.snp.top)
-            }
-
             self.nextButton.snp.updateConstraints { make in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height + 5)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 20)
             }
             self.view.layoutIfNeeded()
         }
@@ -344,23 +329,8 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
 
-            self.headerStackView.snp.updateConstraints { make in
-                make.bottom.equalTo(self.challengeNameTextField.snp.top).offset(-19)
-            }
-
-            self.challengeNameTextField.snp.updateConstraints { make in
-                make.bottom.equalTo(self.challengeRecommendButton.snp.top).offset(-20)
-            }
-            self.startDateStackView.snp.updateConstraints { make in
-                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(43)
-            }
-
-            self.endDateStackView.snp.updateConstraints { make in
-                make.top.equalTo(self.startDateStackView.snp.top)
-            }
-
             self.nextButton.snp.updateConstraints { make in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide)
             }
             self.view.layoutIfNeeded()
         }

--- a/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeEssentialInfoInputScene/ChallengeEssentialInfoInputViewController.swift
@@ -319,6 +319,9 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         
         UIView.animate(withDuration: 0.3) {
+            self.startDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(20)
+            }
             self.nextButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height - 20)
             }
@@ -328,7 +331,9 @@ extension ChallengeEssentialInfoInputViewController: KeyboardDelegate {
 
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: 0.3) {
-
+            self.startDateStackView.snp.updateConstraints { make in
+                make.top.equalTo(self.challengeRecommendButton.snp.bottom).offset(43)
+            }
             self.nextButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide)
             }


### PR DESCRIPTION
## 개요
기존 키보드 올라갈 시 변경되는 레이아웃을 수정했습니다.
## 변경사항
- 챌린지 시작, 추가 정보 화면의 키보드 활성화 시 버튼의 레이아웃만 수정되게 변경했습니다.
( 이전 @kimkyunghun3 님과 PR 리뷰 중 제가 SE도 대응 부탁드려서 수정하셨던 것 같은데 
저도 수정 시도 몇번 했으나 SE 까지 대응하려면 스크롤 뷰를 넣어서 키보드 올라가면 스크롤도 올리는 게 가장 자연스러울 것 같습니다.. 
근데 이 부분은 유저가 많아지면 추후 대응하는게 좋을 것 같아요~! )
- 컴포넌트 사이의 레이아웃을 줄이는 것보다 추가 정보 TextView 높이를 줄이는게 덜 어색하여 수정했습니다.
## 스크린샷
|1|2|
|:--:|:--:|
|![Simulator Screen Recording - iPhone 14 - 2023-08-11 at 14 24 51](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/37755857-f43e-45e7-a3c2-0248cede9897)|![Simulator Screen Recording - iPhone 14 - 2023-08-12 at 09 00 06](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/3fc2cfa3-9660-40d9-951b-d62009490f89)|