### PR TITLE
히스토리 이미지 딤 처리

### DIFF
--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/Cell/CertificateTableViewCell.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/Cell/CertificateTableViewCell.swift
@@ -34,7 +34,7 @@ final class CertificateTableViewCell: UITableViewCell {
         v.textColor = .white
         return v
     }()
-    
+        
     lazy var myImageView: UIImageView = {
         let v = UIImageView()
         v.layer.cornerRadius = 10
@@ -96,6 +96,7 @@ final class CertificateTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.layout()
         self.attribute()
+        self.applyDimming()
     }
     
     required init?(coder: NSCoder) {
@@ -190,5 +191,14 @@ final class CertificateTableViewCell: UITableViewCell {
     func attribute() {
         self.backgroundColor = .clear
         self.selectionStyle = .none
+    }
+
+    func applyDimming() {
+        [self.myImageView, self.partnerImageView].forEach { image in
+            let dimLayer = CALayer()
+            dimLayer.backgroundColor = UIColor.black.withAlphaComponent(0.1).cgColor
+            dimLayer.frame = .init(x: 0, y: 0, width: 127, height: 127)
+            image.layer.addSublayer(dimLayer)
+        }
     }
 }

--- a/Scene/InvitationWaitScene/Sources/InvitationWaitScene/InvitationWaitViewController.swift
+++ b/Scene/InvitationWaitScene/Sources/InvitationWaitScene/InvitationWaitViewController.swift
@@ -64,6 +64,7 @@ final class InvitationWaitViewController: UIViewController {
         let v = UILabel()
         v.textColor = .grey600
         v.font = .body2
+        v.textAlignment = .center
         v.text = "* 만약 초대링크를 잃어버리셨다면, 초대장 다시보내기를 해보세요"
         v.numberOfLines = 0
         return v

--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
@@ -173,6 +173,7 @@ final class MyInfoViewController: UIViewController {
         self.myNameTagView.snp.makeConstraints { make in
             make.top.equalTo(self.challengeCountLabel.snp.bottom).offset(14)
             make.centerX.equalTo(self.mainImageView.snp.centerX)
+            make.height.equalTo(28)
         }
         
         self.separator.snp.makeConstraints { make in


### PR DESCRIPTION
## 개요
- 히스토리 이미지 딤 처리 작업 및 사소한 디자인 이슈를 변경했습니다.
## 변경사항
- 히스토리 이미지 딤 처리 black 10% 작업
- 마이페이지 닉네임 태그 뷰 높이 고정 
- 초대 안내 문구 alignment 가운데로 변경
## 스크린샷
|태그 뷰|딤 처리|
|:---:|:---:|
|![IMG_6074](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/0297a1ed-2216-428c-8397-1b89811e0759)|![IMG_DA9096B62487-1](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/178776ea-002c-4feb-9f98-69b978c47550)|
