### PR TITLE
꽃 선택 화면 이슈 수정

### DIFF
--- a/Scene/FlowerSelectScene/Sources/FlowerSelectScene/FlowerSelectViewController.swift
+++ b/Scene/FlowerSelectScene/Sources/FlowerSelectScene/FlowerSelectViewController.swift
@@ -173,7 +173,7 @@ final class FlowerSelectViewController: UIViewController, TTNavigationDetailBarD
         }
 
         self.challengeButton.snp.makeConstraints { make in
-            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-54)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(20)
             make.leading.equalToSuperview().offset(24)
             make.trailing.equalToSuperview().offset(-24)
         }


### PR DESCRIPTION
## 개요

꽃 선택 화면의 이슈를 수정합니다.

## 변경사항

- CTA 버튼의 위치를 조정합니다.

## 스크린샷

https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/f5d9a2e9-b853-4bad-8be3-84816c6317c1



