### PR TITLE
내 정보 화면 이슈 수정

### DIFF
--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoInteractor.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoInteractor.swift
@@ -10,8 +10,8 @@ import CoreKit
 import Foundation
 
 protocol MyInfoBusinessLogic {
-    /// 첫 진입
-    func didLoad() async
+    /// 진입
+    func didAppear() async
     /// 설명서 버튼 클릭
     func didTapGuideButton() async
     /// Lists에 있는 목록들 클릭
@@ -109,11 +109,11 @@ extension MyInfoInteractor {
     }
 }
 
-// MARK: Feature (첫 진입)
+// MARK: Feature (진입)
 
 extension MyInfoInteractor {
-
-    func didLoad() async {
+    
+    func didAppear() async {
         do {
             let mypageInfo = try await self.worker.fetchMypageInfo()
             

--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
@@ -123,13 +123,17 @@ final class MyInfoViewController: UIViewController {
         super.viewDidLoad()
         self.setUI()
         
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         Task {
             Loading.shared.showLoadingView()
-            await self.interactor.didLoad()
+            await self.interactor.didAppear()
             Loading.shared.stopLoadingView()
         }
-        
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     // MARK: - Layout
@@ -152,8 +156,9 @@ final class MyInfoViewController: UIViewController {
         
         self.mainImageView.snp.makeConstraints { make in
             make.top.equalTo(self.navigationBar.snp.bottom)
-            make.leading.trailing.equalToSuperview().inset(113)
-            make.height.equalTo(UIScreen.main.bounds.height * 0.158)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(149)
+            make.height.equalTo(129)
         }
         
         self.nameStackView.snp.makeConstraints { make in


### PR DESCRIPTION
## 개요

내 정보 화면의 이슈를 수정합니다.

## 변경사항

- 내 정보 화면 진입 순간 마다 새로 고침을 하도록 합니다. (챌린지 순서 동기화 문제)
- 메인 아이콘이 찌그러지는 현상을 수정합니다.

## 스크린샷

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-03 at 15 47 24](https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/3b83b9a7-0117-49cb-b843-e97e4ce7b10e)

