### PR TITLE
사진 관련 버그 수정 및 개선

### DIFF
--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateInteractor.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateInteractor.swift
@@ -139,7 +139,6 @@ extension ChallengeCertificateInteractor {
     
     func didCropImage(image: UIImage) async {
         do {
-            try await self.worker.saveImage(image: image)
             await self.updateCertificateImage(certificateImage: image)
             await self.presenter.presentCertificateImage(image: image)
         }

--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateWorker.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateWorker.swift
@@ -79,7 +79,7 @@ final class ChallengeCertificateWorker: ChallengeCertificateWorkerProtocol {
         guard let challengeNo = Int(challengeID) else {
             throw NSError(domain: "not fount challenge", code: -1)
         }
-        guard let img = certificateImage.jpegData(compressionQuality: 1.0) else {
+        guard let img = self.compressImage(certificateImage) else {
             throw NSError(domain: "not fount img", code: -1)
         }
         let date = Date()
@@ -93,5 +93,40 @@ final class ChallengeCertificateWorker: ChallengeCertificateWorkerProtocol {
             img: img,
             fileName: formattedDate
         )
+    }
+    
+    private func compressImage(
+        _ image: UIImage,
+        quality: CGFloat = 1,
+        maxWidth: CGFloat = 1920,
+        maxHeight: CGFloat = 1920
+    ) -> Data? {
+        var actualHeight: CGFloat = image.size.height
+        var actualWidth: CGFloat = image.size.width
+        var imgRatio: CGFloat = actualWidth / actualHeight
+        let maxRatio: CGFloat = maxWidth / maxHeight
+
+        if actualHeight > maxHeight || actualWidth > maxWidth {
+            if imgRatio < maxRatio {
+                imgRatio = maxHeight / actualHeight
+                actualWidth = imgRatio * actualWidth
+                actualHeight = maxHeight
+            } else if imgRatio > maxRatio {
+                imgRatio = maxWidth / actualWidth
+                actualHeight = imgRatio * actualHeight
+                actualWidth = maxWidth
+            } else {
+                actualHeight = maxHeight
+                actualWidth = maxWidth
+            }
+        }
+
+        let rect = CGRect(x: 0.0, y: 0.0, width: actualWidth, height: actualHeight)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, 1.0)
+        image.draw(in: rect)
+        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return resizedImage?.jpegData(compressionQuality: quality)
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Package.swift
+++ b/Scene/ChallengeHistoryDetailScene/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
     dependencies: [
         .package(path: "./CoreKit"),
         .package(
+            url: "https://github.com/suzuki-0000/SKPhotoBrowser",
+            .upToNextMajor(from: "7.0.0")
+        ),
+        .package(
             url: "https://github.com/Quick/Nimble",
             .upToNextMajor(from: "12.0.0")
         ),
@@ -27,7 +31,8 @@ let package = Package(
         .target(
             name: "ChallengeHistoryDetailScene",
             dependencies: [
-                .product(name: "CoreKit", package: "CoreKit")
+                .product(name: "CoreKit", package: "CoreKit"),
+                .product(name: "SKPhotoBrowser", package: "SKPhotoBrowser")
             ],
             resources: [.process("Assets")]
         ),

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -13,6 +13,8 @@ protocol ChallengeHistoryDetailBusinessLogic {
     func didLoad() async
     /// 닫기 버튼 클릭
     func didTapCloseButton() async
+    /// 사진 클릭
+    func didTapPhoto() async
 }
 
 protocol ChallengeHistoryDetailDataStore: AnyObject {
@@ -62,6 +64,15 @@ extension ChallengeHistoryDetailInteractor {
         await self.presenter.presentChallengeDetail(detail: self.detail)
     }
     
+}
+
+// MARK: - Feature (사진 상세)
+
+extension ChallengeHistoryDetailInteractor {
+    
+    func didTapPhoto() async {
+        await self.presenter.presentPhoto(imageUrl: self.detail.certificateImageUrl)
+    }
 }
 
 // MARK: Feature (닫기)

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SKPhotoBrowser
 
 enum ChallengeHistoryDetail {
     
@@ -59,6 +60,11 @@ enum ChallengeHistoryDetail {
             var complimentTitle: String
             /// 칭찬 문구
             var complimentComment: String?
+        }
+        
+        /// 사진
+        struct Photo {
+            var images: [SKPhoto]
         }
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -7,10 +7,12 @@
 //
 
 import UIKit
+import SKPhotoBrowser
 
 @MainActor
 protocol ChallengeHistoryDetailPresentationLogic {
     func presentChallengeDetail(detail: ChallengeHistoryDetail.Model.ChallengeDetail)
+    func presentPhoto(imageUrl: String)
     
 }
 
@@ -27,6 +29,14 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
         let (certification, compliment) = self.map(detail)
         self.viewController?.displayCertification(certification: certification)
         self.viewController?.displayCompliment(compliment: compliment)
+    }
+    
+    func presentPhoto(imageUrl: String) {
+        var images = [SKPhoto]()
+        let photo = SKPhoto.photoWithImageURL(imageUrl)
+        photo.shouldCachePhotoURLImage = false
+        images.append(photo)
+        self.viewController?.displayPhoto(photo: .init(images: images))
     }
     
     // model -> viewModel

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -8,10 +8,12 @@
 
 import CoreKit
 import UIKit
+import SKPhotoBrowser
 
 protocol ChallengeHistoryDetailDisplayLogic: AnyObject {
     func displayCertification(certification: ChallengeHistoryDetail.ViewModel.Challenge)
     func displayCompliment(compliment: ChallengeHistoryDetail.ViewModel.Compliment)
+    func displayPhoto(photo: ChallengeHistoryDetail.ViewModel.Photo)
 }
 
 final class ChallengeHistoryDetailViewController: UIViewController {
@@ -45,6 +47,12 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         let v = UIImageView()
         v.layer.cornerRadius = 10
         v.clipsToBounds = true
+        v.isUserInteractionEnabled = true
+        v.addTapAction { [weak self] in
+            Task { [weak self] in
+                await self?.interactor.didTapPhoto()
+            }
+        }
         return v
     }()
     /// 챌린지 이름 라벨
@@ -59,6 +67,7 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         let v = UILabel()
         v.font = .h4
         v.textColor = .primary
+        v.numberOfLines = 0
         return v
     }()
     /// 인증 시간 라벨
@@ -245,5 +254,9 @@ extension ChallengeHistoryDetailViewController: ChallengeHistoryDetailDisplayLog
         }
     }
     
-    
+    func displayPhoto(photo: ChallengeHistoryDetail.ViewModel.Photo) {
+        let browser = SKPhotoBrowser(photos: photo.images)
+        browser.initializePageIndex(0)
+        self.present(browser, animated: true, completion: {})
+    }
 }


### PR DESCRIPTION
## 개요

- 사진 관련 버그를 수정 및 개선합니다.

## 변경사항

- 인증 시에 사진을 디폴트로 저장하는 코드를 삭제합니다
- 사진을 최대 해상도 1920x1920 으로 압축, 최적화 합니다
- 인증 상세에서 사진 뷰어를 볼 수 있게 합니다

++ 인증 상세에서 인증 문구가 여러줄이 보일수 있도록 합니다

## 스크린샷

https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/5b2f612d-8840-4f71-8438-5acb2e69146f


