### PR TITLE
메인 화면 랜딩 시에 검은 화면 약 0.1 초간 노출 이슈 해결

### DIFF
--- a/Scene/MainScene/Sources/MainScene/MainTabBarController.swift
+++ b/Scene/MainScene/Sources/MainScene/MainTabBarController.swift
@@ -42,7 +42,7 @@ final class MainTabBarController: UITabBarController {
     // MARK: - Layout
     
     private func setUI() {
-        self.view.backgroundColor = .clear
+        self.view.setBackgroundDefault()
     }
     
     func setTab(_ tab: Main.ViewModel.MainTab) {


### PR DESCRIPTION
## 개요

메인 화면 랜딩 시에 검은 화면 약 0.1 초간 노출 이슈 해결합니다.

## 변경사항

- 메인 탭바의 배경 색상을 기본 색상으로 변경하였습니다.

## 스크린샷

### Before
https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/aeb07790-ac71-44b1-9b65-475e1d42d748

### After
https://github.com/mash-up-kr/TwoToo_iOS/assets/39177603/ea754614-c376-497f-a9a0-bbb8118c4ce5

