### PR TITLE
히스토리 관련 이슈 수정

### DIFF
--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryViewController.swift
@@ -57,7 +57,7 @@ final class HistoryViewController: UIViewController, TTNavigationBarDelegate, UI
         let v = UILabel()
         v.textColor = .grey500
         v.font = .h3
-        v.text = "챌린지를 완료해\n히스토리를 만들어보세요 :)"
+        v.text = "진행중인 챌린지가 없어요\n챌린지를 만들어보세요 :)"
         v.setLineSpacing(10)
         v.textAlignment = .center
         v.numberOfLines = 0

--- a/Scene/HistoryScene/Sources/HistoryScene/HistoryWorker.swift
+++ b/Scene/HistoryScene/Sources/HistoryScene/HistoryWorker.swift
@@ -37,8 +37,8 @@ final class HistoryWorker: HistoryWorkerProtocol {
                     name: history.name,
                     startDate: history.startDate.fullStringDate(.iso),
                     endDate: history.endDate.fullStringDate(.iso),
-                    myFlower: history.user1CommitCnt < 17 ? self.mapFlowerType(from: history.user1Flower) : self.mapFlowerType(from: history.user1Flower),
-                    partnerFlower: history.user2CommitCnt < 17 ? self.mapFlowerType(from: history.user2Flower) : self.mapFlowerType(from: history.user2Flower)
+                    myFlower: history.user1CommitCnt < 17 ? nil : self.mapFlowerType(from: history.user1Flower),
+                    partnerFlower: history.user2CommitCnt < 17 ? nil : self.mapFlowerType(from: history.user2Flower)
                 )
             }).reversed()
         }


### PR DESCRIPTION
## 개요
챌린지 실패한 꽃을 기본 새싹으로 변경합니다.
챌린지가 없을 때 나오는 문구를 수정합니다.

## 변경사항
- 챌린지 실패 시 꽃 기본 새싹 변경
- 챌린지 부재시 문구 수정

## 스크린샷
![IMG_9907](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/91970f8c-9ba5-4f50-80d9-54902f99c8b3)
![IMG_9914](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/18b8a85c-2053-47df-9b7c-1c53395daeef)

