### PR TITLE
마이페이지, 닉네임 변경 페이지 Font 및 alignment 수정

### DIFF
--- a/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
+++ b/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
@@ -45,6 +45,7 @@ final class ChangeNicknameViewController: UIViewController {
         let v = UILabel()
         v.setLineSpacing(11)
         v.text = "변경할 닉네임을\n입력해주세요"
+        v.textAlignment = .center
         v.font = .h1
         v.textColor = .primary
         v.numberOfLines = 0

--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
@@ -51,14 +51,14 @@ final class MyInfoViewController: UIViewController {
     private lazy var myNicknameLabel: UILabel = {
         let v = UILabel()
         v.textColor = .mainCoral
-        v.font = .body3
+        v.font = .body2
         return v
     }()
     
     private lazy var partnerNicknameLabel: UILabel = {
         let v = UILabel()
         v.textColor = .mainCoral
-        v.font = .body3
+        v.font = .body2
         return v
     }()
     
@@ -71,7 +71,7 @@ final class MyInfoViewController: UIViewController {
     private lazy var challengeCountLabel: UILabel = {
         let v = UILabel()
         v.textColor = .mainCoral
-        v.font = .body3
+        v.font = .body2
         return v
     }()
     
@@ -190,7 +190,7 @@ final class MyInfoViewController: UIViewController {
         }
         
         self.heartImageView.snp.makeConstraints { make in
-            make.height.width.equalTo(10)
+            make.height.width.equalTo(14)
         }
         
         self.challengeCountLabel.snp.makeConstraints { make in


### PR DESCRIPTION
## 개요
- 마이페이지 내의 폰트 크기를 조정합니다.
- 닉네임 변경 text alignment를 바꿉니다.

## 변경사항
- 마이페이지 내의 닉네임 하트 텍스트, 하트 텍스트 title의 폰트를 body2로 변경합니다.
- 닉네임 변경 타이틀의 정렬을 center로 바꿉니다.

## 스크린샷
![IMG_9906](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/5e61e998-8b8f-4af0-8a30-152cabde501e)
![IMG_9904](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/960129de-3d76-4880-a0c9-17e64cbd4208)

