### PR TITLE
홈 프로그레스 바 큰 사이즈 화면 대응

### DIFF
--- a/Scene/HomeScene/Sources/HomeScene/Views/Common/TTProgressBar.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/Common/TTProgressBar.swift
@@ -92,15 +92,18 @@ final class TTProgressBar: UIView {
                          self.myNicknameLabel,
                          self.myPercentContentView,
                          self.myPercentLabel)
+        
+        let percentContentLeadingOffset = UIDevice.current.deviceType == .default ? 9 : 14
+
         // --> partner
         self.partnerNicknameLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview().multipliedBy(0.3)
             make.centerY.equalToSuperview().multipliedBy(0.6)
         }
-        
+                
         self.partnerPercentContentView.snp.makeConstraints { make in
-            make.width.equalTo(100)
-            make.trailing.equalToSuperview().inset(43)
+            make.leading.equalTo(self.partnerNicknameLabel.snp.trailing).offset(percentContentLeadingOffset)
+            make.trailing.equalTo(self.partnerPercentLabel.snp.leading).offset(-6)
             make.height.equalToSuperview().dividedBy(5.5)
             make.centerY.equalToSuperview().multipliedBy(0.6)
         }
@@ -117,8 +120,8 @@ final class TTProgressBar: UIView {
         }
         
         self.myPercentContentView.snp.makeConstraints { make in
-            make.width.equalTo(100)
-            make.trailing.equalToSuperview().inset(43)
+            make.leading.equalTo(self.myNicknameLabel.snp.trailing).offset(percentContentLeadingOffset)
+            make.trailing.equalTo(self.myPercentLabel.snp.leading).offset(-6)
             make.height.equalToSuperview().dividedBy(5.5)
             make.centerY.equalToSuperview().multipliedBy(1.4)
         }


### PR DESCRIPTION
## 개요
홈 프로그래스 바 레이아웃을 수정해 큰 사이즈를 대응합니다.
## 변경사항
개요 동일
## 스크린샷
- iPhone 15 Plus
![simulator_screenshot_69ED3C66-20D8-4466-8BE3-B815560742D7](https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/eccfc53a-6fdc-4dde-be8c-d9c5759b5c2d)
