### PR TITLE
회원 탈퇴, 챌린지 삭제하기 Popup 문구 수정

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTPopup.swift
@@ -47,6 +47,7 @@ public final class TTPopup: UIView, UIComponentBased {
         v.font = .omyupretty(size: ._16)
         v.numberOfLines = 0
         v.textColor = .grey500
+        v.isHidden = true
         return v
     }()
     
@@ -120,7 +121,7 @@ public final class TTPopup: UIView, UIComponentBased {
     
     public func configure(title: String,
                           resultView: UIView,
-                          description: String,
+                          description: String = "",
                           warningText: String = "",
                           buttonTitles: [String]) {
         self.titleLabel.text = title
@@ -129,9 +130,12 @@ public final class TTPopup: UIView, UIComponentBased {
             make.centerX.centerY.equalToSuperview()
         }
         
-        self.descriptionLabel.text = description
-        self.descriptionLabel.setLineSpacing(8)
-        self.descriptionLabel.textAlignment = .center
+        if !description.isEmpty {
+            self.descriptionLabel.isHidden = false
+            self.descriptionLabel.text = description
+            self.descriptionLabel.setLineSpacing(8)
+            self.descriptionLabel.textAlignment = .center
+        }
         
         if !warningText.isEmpty {
             self.waringLabel.isHidden = false

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
@@ -52,7 +52,7 @@ extension ChallengeHistoryPresenter: ChallengeHistoryPresentationLogic {
         var buttonTitles: [String] = ["취소", "그만두기"]
         if self.isCompleted {
             title = "챌린지 삭제하기"
-            description = "선택한 챌린지는 삭제됩니다."
+            description = "완료한 챌린지는 삭제됩니다."
             warningText = "*(경고) 삭제하기 시 양쪽 모두에게 삭제됩니다!*"
             buttonTitles = ["취소", "삭제하기"]
         }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
@@ -52,8 +52,8 @@ extension ChallengeHistoryPresenter: ChallengeHistoryPresentationLogic {
         var buttonTitles: [String] = ["취소", "그만두기"]
         if self.isCompleted {
             title = "챌린지 삭제하기"
-            description = "선택한 챌린지는 삭제됩니다.\n"
-            warningText = ""
+            description = "선택한 챌린지는 삭제됩니다."
+            warningText = "*(경고) 삭제하기 시 양쪽 모두에게 삭제됩니다!*"
             buttonTitles = ["취소", "삭제하기"]
         }
         

--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoModels.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoModels.swift
@@ -54,7 +54,7 @@ enum MyInfo {
             /// 타이틀
             static let title: String = "회원 탈퇴하기"
             /// 메세지
-            static let message: String = "파트너도 같이 삭제 되어요."
+            static let warning: String = "*(경고) 회원 탈퇴 시 모든 기록이 삭제되고 복구가 불가능합니다. 또한 파트너 정보도 함께 삭제됩니다!*"
             /// 취소
             static let cancelOptionText: String = "취소"
             /// 탈퇴하기 옵션

--- a/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
+++ b/Scene/MyInfoScene/Sources/MyInfoScene/MyInfoViewController.swift
@@ -250,7 +250,7 @@ extension MyInfoViewController: MyInfoDisplayLogic {
             let popupView = TTPopup()
             popupView.configure(title: MyInfo.ViewModel.SignOutViewModel.title,
                                 resultView: popupContentView,
-                                description: MyInfo.ViewModel.SignOutViewModel.message,
+                                warningText: MyInfo.ViewModel.SignOutViewModel.warning,
                                 buttonTitles: [
                                     MyInfo.ViewModel.SignOutViewModel.cancelOptionText,
                                     MyInfo.ViewModel.SignOutViewModel.signOutOptionText


### PR DESCRIPTION
## 개요
- 회원탈퇴, 챌린지 삭제하기 Popup 문구를 수정합니다.

## 변경사항
- 회원탈퇴 문구 : *(경고) 회원 탈퇴 시 모든 기록이 삭제되고 복구가 불가능합니다. 또한 파트너 정보도 함께 삭제됩니다!*
- 챌린지 삭제하기 문구 : 완료한 챌린지는 삭제 됩니다. (경고) 삭제하기 시 양쪽 모두에게 삭제됩니다!*

## 스크린샷
![IMG_9909](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/944c30cc-2b26-4525-a640-d6bfdc183391)

![IMG_9910](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/2565f4fa-27c1-4430-b481-928568bfbfb5)

