### PR TITLE
챌린지 히스토리 퍼센테이지바 구현

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTProgressBar.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/TTProgressBar.swift
@@ -7,7 +7,22 @@
 
 import UIKit
 
-final class TTProgressBar: UIView {
+public protocol TTProgressViewModelProtocol {
+    /// 상대방 이름 텍스트
+    var partnerNameText: String { get set }
+    /// 내 이름 텍스트
+    var myNameText: String { get set }
+    /// 상대방 퍼센테이지 텍스트
+    var partnerPercentageText: String { get set }
+    /// 내 퍼센테이지 텍스트
+    var myPercentageText: String { get set }
+    /// 상대방 퍼센테이지 넘버
+    var partnerPercentageNumber: Double { get set }
+    /// 내 퍼센테이지 넘버
+    var myPercentageNumber: Double { get set }
+}
+
+public final class TTProgressBar: UIView {
     
     // MARK: - My UI
     private lazy var partnerNicknameLabel: UILabel = {
@@ -137,7 +152,7 @@ final class TTProgressBar: UIView {
         self.layer.cornerRadius = 15
     }
     
-    func configureInProgress(viewModel: Home.ViewModel.ChallengeInProgressViewModel.ProgressViewModel) {
+    public func configure(viewModel: TTProgressViewModelProtocol) {
         self.myNicknameLabel.text = viewModel.myNameText
         self.myPercentLabel.text = viewModel.myPercentageText
         self.partnerNicknameLabel.text = viewModel.partnerNameText
@@ -145,16 +160,6 @@ final class TTProgressBar: UIView {
         self.configurePercent(my: viewModel.myPercentageNumber,
                               partner: viewModel.partnerPercentageNumber)
     }
-    
-    func configureCompleted(viewModel: Home.ViewModel.ChallengeCompletedViewModel.ProgressViewModel) {
-        self.myNicknameLabel.text = viewModel.myNameText
-        self.myPercentLabel.text = viewModel.myPercentageText
-        self.partnerNicknameLabel.text = viewModel.partnerNameText
-        self.partnerPercentLabel.text = viewModel.partnerPercentageText
-        self.configurePercent(my: viewModel.myPercentageNumber,
-                              partner: viewModel.partnerPercentageNumber)
-    }
-    
     
     private func configurePercent(my: Double, partner: Double) {
         if my == 0 {

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryModels.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryModels.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2023 TwoToo. All rights reserved.
 //
 
+import CoreKit
 import UIKit
 
 enum ChallengeHistory {
@@ -40,6 +41,8 @@ enum ChallengeHistory {
             var id: String
             /// 닉네임
             var nickname: String
+            /// 인증 횟수
+            var certCount: Int?
             /// 인증 리스트
             var certificates: [Certificate]
         }
@@ -73,12 +76,30 @@ enum ChallengeHistory {
             var dDayText: String
             /// 챌린지 추가 정보 문구
             var additionalInfo: String?
+            /// 프로그래스
+            var progress: ProgressViewModel
             /// 유저 닉네임
             var myNickname: String
             /// 상대방 닉네임
             var partnerNickname: String
             /// 셀 정보
             var cellInfo: CellInfoList
+        }
+        
+        /// 프로그래스
+        struct ProgressViewModel: TTProgressViewModelProtocol {
+            /// 상대방 이름 텍스트
+            var partnerNameText: String
+            /// 내 이름 텍스트
+            var myNameText: String
+            /// 상대방 퍼센테이지 텍스트
+            var partnerPercentageText: String
+            /// 내 퍼센테이지 텍스트
+            var myPercentageText: String
+            /// 상대방 퍼센테이지 넘버
+            var partnerPercentageNumber: Double
+            /// 내 퍼센테이지 넘버
+            var myPercentageNumber: Double
         }
         
         /// 챌린지 테이블 셀 리스트

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryPresenter.swift
@@ -89,13 +89,23 @@ extension ChallengeHistoryPresenter {
                      dDayText: self.makedDayText(start: Date(),
                                                  end: model.endDate,
                                                  isFinished: model.isFinished),
-                     additionalInfo: model.additionalInfo,
+                     additionalInfo: model.additionalInfo, 
+                     progress: self.mappingProgress(partnerInfo: model.partnerInfo, myInfo: model.myInfo),
                      myNickname: model.myInfo.nickname,
                      partnerNickname: model.partnerInfo.nickname,
                      cellInfo: self.makeCellInfoList(start: model.startDate,
                                                      end: model.endDate,
                                                      myList: model.myInfo.certificates,
                                                      partnerList: model.partnerInfo.certificates))
+    }
+    
+    private func mappingProgress(partnerInfo: ChallengeHistory.Model.User, myInfo: ChallengeHistory.Model.User) -> ChallengeHistory.ViewModel.ProgressViewModel {
+        return .init(partnerNameText: partnerInfo.nickname,
+                     myNameText: myInfo.nickname,
+                     partnerPercentageText: self.calculatePercentageText(certCount: partnerInfo.certCount),
+                     myPercentageText: self.calculatePercentageText(certCount: myInfo.certCount),
+                     partnerPercentageNumber: self.calculatePercentageNumber(certCount: partnerInfo.certCount),
+                     myPercentageNumber: self.calculatePercentageNumber(certCount: myInfo.certCount))
     }
     /// cell 뷰모델 리스트 생성
     private func makeCellInfoList(start: Date,
@@ -192,5 +202,35 @@ extension ChallengeHistoryPresenter {
         let today = Date()
         return Calendar.current.isDate(today, inSameDayAs: date)
     }
+    
+    private func calculatePercentageText(certCount: Int?) -> String {
+        guard let certCount = certCount else {
+            return ""
+        }
+        
+        if certCount < 20 {
+            let percentage = (certCount * 5) // 5% 씩 증가
+            return "\(percentage)%"
+        } else if certCount < 22 {
+            return "99%" // 20부터 99%로 유지
+        } else {
+            return "100%" // 22가 되면 100%로 표시
+        }
+    }
+
+    private func calculatePercentageNumber(certCount: Int?) -> Double {
+        guard let certCount = certCount else {
+            return 0.0
+        }
+        
+        if certCount < 20 {
+            return Double(certCount) * 0.05 // 5% 씩 증가
+        } else if certCount < 22 {
+            return 0.99 // 20부터 99%로 유지
+        } else {
+            return 1.0 // 22가 되면 100%로 표시
+        }
+    }
+    
     
 }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryViewController.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryViewController.swift
@@ -67,6 +67,12 @@ final class ChallengeHistoryViewController: UIViewController, UITableViewDataSou
         return v
     }()
     
+    private let progressBar: TTProgressBar = {
+        let v = TTProgressBar()
+        v.isHidden = true
+        return v
+    }()
+    
     private let myNicknameTagView: TTTagView = {
         let v = TTTagView(textColor: .mainCoral,
                           fontSize: .body2,
@@ -166,6 +172,7 @@ final class ChallengeHistoryViewController: UIViewController, UITableViewDataSou
                               self.dDayTagView,
                               self.titleLabel,
                               self.additionalInfoLabel,
+                              self.progressBar,
                               self.myNicknameTagView,
                               self.partnerNicknameTagView,
                               self.underLineView,
@@ -199,14 +206,21 @@ final class ChallengeHistoryViewController: UIViewController, UITableViewDataSou
             make.trailing.equalToSuperview().inset(25)
         }
         
+        self.progressBar.snp.makeConstraints { make in
+            make.top.equalTo(self.additionalInfoLabel.snp.bottom).offset(12)
+            make.leading.equalToSuperview().offset(24)
+            make.width.equalToSuperview().multipliedBy(0.55)
+            make.height.equalTo(62)
+        }
+        
         self.partnerNicknameTagView.snp.makeConstraints { make in
-            make.top.equalTo(self.additionalInfoLabel.snp.bottom).offset(40)
+            make.top.equalTo(self.progressBar.snp.bottom).offset(30)
             make.centerX.equalToSuperview().multipliedBy(0.5)
             make.height.equalTo(28)
         }
         
         self.myNicknameTagView.snp.makeConstraints { make in
-            make.top.equalTo(self.additionalInfoLabel.snp.bottom).offset(40)
+            make.top.equalTo(self.progressBar.snp.bottom).offset(30)
             make.centerX.equalToSuperview().multipliedBy(1.5)
             make.height.equalTo(28)
         }
@@ -231,6 +245,7 @@ final class ChallengeHistoryViewController: UIViewController, UITableViewDataSou
             make.height.equalTo(349)
         }
     }
+    
     // MARK: - UITableViewDataSource
     var certificateList: ChallengeHistory.ViewModel.CellInfoList = []
     
@@ -300,8 +315,11 @@ extension ChallengeHistoryViewController: ChallengeHistoryDisplayLogic {
         self.myNicknameTagView.titleLabel.text = viewModel.myNickname
         self.partnerNicknameTagView.titleLabel.text = viewModel.partnerNickname
         self.certificateList = viewModel.cellInfo
+        self.progressBar.isHidden = false
+        self.progressBar.configure(viewModel: viewModel.progress)
         self.certificateTableView.reloadData()
     }
+    
 
     func displayOptionPopup(title: String) {
         let alertVC = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryWorker.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryWorker.swift
@@ -97,7 +97,11 @@ final class ChallengeHistoryWorker: ChallengeHistoryWorkerProtocol {
         return self.meLocalWorker.partnerNickname
     }
     
-    private func mapUserInfo(from user: ChallengeDetailResponse.User, commitList: [ChallengeDetailResponse.Commit]?, commitCount: Int?) -> ChallengeHistory.Model.User {
+    private func mapUserInfo(from user: ChallengeDetailResponse.User, 
+                             commitList: [ChallengeDetailResponse.Commit]?,
+                             commitCount: Int?) 
+    -> ChallengeHistory.Model.User 
+    {
         var certificates: [ChallengeHistory.Model.Certificate] = []
         if let commitList = commitList {
             certificates = commitList.map {
@@ -114,6 +118,7 @@ final class ChallengeHistoryWorker: ChallengeHistoryWorkerProtocol {
         let userInfo: ChallengeHistory.Model.User = .init(
             id: String(user.userNo),
             nickname: user.nickname,
+            certCount: commitCount,
             certificates: certificates
         )
         

--- a/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
@@ -193,7 +193,7 @@ enum Home {
             }
             
             /// 프로그래스
-            struct ProgressViewModel {
+            struct ProgressViewModel: TTProgressViewModelProtocol {
                 /// 상대방 이름 텍스트
                 var partnerNameText: String
                 /// 내 이름 텍스트
@@ -298,7 +298,7 @@ enum Home {
             }
 
             /// 프로그래스
-            struct ProgressViewModel {
+            struct ProgressViewModel: TTProgressViewModelProtocol {
                 /// 상대방 이름 텍스트
                 var partnerNameText: String
                 /// 내 이름 텍스트

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
@@ -33,6 +33,7 @@ final class ChallengeCompletedView: UIView {
     /// 챌린지 진행도 뷰
     lazy var progressBar: TTProgressBar = {
         let v = TTProgressBar()
+        v.isHidden = true
         return v
     }()
     /// 나와 상대의 닉네임 뷰
@@ -156,7 +157,7 @@ final class ChallengeCompletedView: UIView {
     
     func configure(viewModel: Home.ViewModel.ChallengeCompletedViewModel) {
         self.topChallengeInfoView.configureCompleted(viewModel: viewModel.challengeInfo)
-        self.progressBar.configureCompleted(viewModel: viewModel.progress)
+        self.progressBar.configure(viewModel: viewModel.progress)
         self.nicknameStackView.configure(challengeOrderText: viewModel.order.challengeOrderText,
                                          myNickname: viewModel.order.myNameText,
                                          partnerNickname: viewModel.order.partenrNameText)

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeInProgressView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import DesignSystem
 
 protocol ChallengeInProgressViewDelegate: AnyObject {
     func didTapCertificateButton()
@@ -176,7 +177,7 @@ final class ChallengeInProgressView: UIView {
     
     func configure(viewModel: Home.ViewModel.ChallengeInProgressViewModel) {
         self.topChallengeInfoView.configureInProgress(viewModel: viewModel.challengeInfo)
-        self.progressBar.configureInProgress(viewModel: viewModel.progress)
+        self.progressBar.configure(viewModel: viewModel.progress)
         self.nicknameStackView.configure(challengeOrderText: viewModel.order.challengeOrderText,
                                          myNickname: viewModel.order.myNameText,
                                          partnerNickname: viewModel.order.partenrNameText)


### PR DESCRIPTION
## 개요
챌린지 히스토리의 퍼센테이지 작업을 합니다.
## 변경사항
- 홈 화면의 퍼센테이지바 컴포넌트를 공통으로 사용합니다.
- 챌린지 히스토리 화면에 퍼센테이지바를 추가합니다.
## 스크린샷
https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/a27fe454-9683-4bf1-afdb-68eeec353edf
