### PR TITLE
칭찬하기 기능 Flow 수정

### DIFF
--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -24,14 +24,14 @@ protocol ChallengeHistoryDetailDataStore: AnyObject {
     var detail: ChallengeHistoryDetail.Model.ChallengeDetail { get }
 }
 
-final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, ChallengeHistoryDetailBusinessLogic {  
-    
+final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, ChallengeHistoryDetailBusinessLogic {
+
     var cancellables: Set<AnyCancellable> = []
-    
+
     var presenter: ChallengeHistoryDetailPresentationLogic
     var router: ChallengeHistoryDetailRoutingLogic
     var worker: ChallengeHistoryDetailWorkerProtocol
-    
+
     init(
         presenter: ChallengeHistoryDetailPresentationLogic,
         router: ChallengeHistoryDetailRoutingLogic,
@@ -43,7 +43,7 @@ final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, C
         self.worker = worker
         self.detail = detail
     }
-    
+
     // MARK: - DataStore
     var detail: ChallengeHistoryDetail.Model.ChallengeDetail
 }
@@ -51,10 +51,10 @@ final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, C
 // MARK: - Interactive Business Logic
 
 extension ChallengeHistoryDetailInteractor {
-    
+
     /// 외부 액션 옵저빙
     func observe() {
-        
+
     }
 }
 
@@ -63,17 +63,21 @@ extension ChallengeHistoryDetailInteractor {
 extension ChallengeHistoryDetailInteractor {
 
     func didLoad() async {
-        await self.presenter.presentChallengeDetail(detail: self.detail)
+        do {
+            try await self.worker.requestChallengeDetailInquiry(challengeID: self.detail.challengeID)
+            await self.presenter.presentChallengeDetail(detail: self.detail)
+        } catch {
+            print("실패")
+        }
     }
-    
 }
 
 // MARK: - Feature (사진 상세)
 
 extension ChallengeHistoryDetailInteractor {
-    
+
     func didTapPhoto() async {
-      await self.presenter.presentPhoto(imageUrl: self.detail.certificateImageUrl)
+        await self.presenter.presentPhoto(imageUrl: self.detail.certificateImageUrl)
     }
 }
 
@@ -90,11 +94,11 @@ extension ChallengeHistoryDetailInteractor {
 
 extension ChallengeHistoryDetailInteractor {
 
-  func didTapPraiseButton() async {
-    if self.detail.complicateComment?.isEmpty != nil {
-      await self.router.routeToPraiseSendScene()
+    func didTapPraiseButton() async {
+        if self.detail.complicateComment?.isEmpty != nil {
+            await self.router.routeToPraiseSendScene()
+        }
     }
-  }
 }
 
 
@@ -103,5 +107,5 @@ extension ChallengeHistoryDetailInteractor {
 // MARK: UseCase ()
 
 extension ChallengeHistoryDetailInteractor {
-    
+
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -69,7 +69,7 @@ extension ChallengeHistoryDetailInteractor {
             self.detail = challenge
             await self.presenter.presentChallengeDetail(detail: self.detail)
         } catch {
-            print("히스토리 디테일 가져오기 실패했습니다.")
+            await self.presenter.presentHistoryDetailError(error: error)
         }
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -97,7 +97,7 @@ extension ChallengeHistoryDetailInteractor {
 extension ChallengeHistoryDetailInteractor {
 
     func didTapPraiseButton() async {
-        if self.detail.complicateComment?.isEmpty != nil {
+        if (self.detail.complicateComment ?? "").isEmpty {
             await self.router.routeToPraiseSendScene()
         }
     }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -15,6 +15,8 @@ protocol ChallengeHistoryDetailBusinessLogic {
     func didTapCloseButton() async
     /// 사진 클릭
     func didTapPhoto() async
+    /// 칭찬하기 버튼 클릭
+    func didTapPraiseButton() async
 }
 
 protocol ChallengeHistoryDetailDataStore: AnyObject {
@@ -22,7 +24,7 @@ protocol ChallengeHistoryDetailDataStore: AnyObject {
     var detail: ChallengeHistoryDetail.Model.ChallengeDetail { get }
 }
 
-final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, ChallengeHistoryDetailBusinessLogic {
+final class ChallengeHistoryDetailInteractor: ChallengeHistoryDetailDataStore, ChallengeHistoryDetailBusinessLogic {  
     
     var cancellables: Set<AnyCancellable> = []
     
@@ -71,7 +73,7 @@ extension ChallengeHistoryDetailInteractor {
 extension ChallengeHistoryDetailInteractor {
     
     func didTapPhoto() async {
-        await self.presenter.presentPhoto(imageUrl: self.detail.certificateImageUrl)
+      await self.presenter.presentPhoto(imageUrl: self.detail.certificateImageUrl)
     }
 }
 
@@ -82,7 +84,17 @@ extension ChallengeHistoryDetailInteractor {
     func didTapCloseButton() async {
         await self.router.dismiss()
     }
-    
+}
+
+// MARK: Feature (칭찬하기)
+
+extension ChallengeHistoryDetailInteractor {
+
+  func didTapPraiseButton() async {
+    if self.detail.complicateComment?.isEmpty != nil {
+      await self.router.routeToPraiseSendScene()
+    }
+  }
 }
 
 

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailInteractor.swift
@@ -64,10 +64,12 @@ extension ChallengeHistoryDetailInteractor {
 
     func didLoad() async {
         do {
-            try await self.worker.requestChallengeDetailInquiry(challengeID: self.detail.challengeID)
+            let challenge = try await self.worker
+                .requestChallengeDetailInquiry(challengeID: self.detail.challengeID, commitID: Int(self.detail.id) ?? 0)
+            self.detail = challenge
             await self.presenter.presentChallengeDetail(detail: self.detail)
         } catch {
-            print("실패")
+            print("히스토리 디테일 가져오기 실패했습니다.")
         }
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
@@ -33,6 +33,8 @@ enum ChallengeHistoryDetail {
             var partnerNickname: String
             /// 칭찬 문구
             var complicateComment: String?
+            /// 내 챌린지 상세정보 여부
+            var isMyHistoryDetail: Bool
         }
  
     }
@@ -60,6 +62,8 @@ enum ChallengeHistoryDetail {
             var complimentTitle: String
             /// 칭찬 문구
             var complimentComment: String?
+            /// 내 히스토리 디테일 여부
+            var isMyHitstoyDetail: Bool
         }
         
         /// 사진

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
@@ -17,6 +17,8 @@ enum ChallengeHistoryDetail {
         
         /// 챌린지 상세 정보
         struct ChallengeDetail: Equatable {
+            /// 챌린지 ID
+            var challengeID: String
             /// 인증 ID
             var id: String
             /// 챌린지 이름

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
@@ -71,5 +71,9 @@ enum ChallengeHistoryDetail {
         struct Photo {
             var images: [SKPhoto]
         }
+
+        struct Toast {
+            var message: String?
+        }
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailModels.swift
@@ -36,9 +36,8 @@ enum ChallengeHistoryDetail {
             /// 칭찬 문구
             var complicateComment: String?
             /// 내 챌린지 상세정보 여부
-            var isMyHistoryDetail: Bool
+            var isMine: Bool
         }
- 
     }
     
     enum ViewModel {

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -46,7 +46,7 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
     {
         let dateText = model.certificateTime.dateToString(.hangleYearMonthDay)
         let timeText = "인증 시간  " + model.certificateTime.dateToString(.hourMinute)
-        let title = "\(model.isMyHistoryDetail ? model.myNickname : model.partnerNickname)의 기록"
+        let title = "\(model.myNickname)의 기록"
         let certification = ChallengeHistoryDetail.ViewModel.Challenge(
           challengeName: model.challengeName,
           certificationDateText: dateText,
@@ -60,7 +60,7 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
         let compliment = ChallengeHistoryDetail.ViewModel.Compliment(
           complimentTitle: complimentTitle,
           complimentComment: model.complicateComment, 
-          isMyHitstoyDetail: model.isMyHistoryDetail
+          isMyHitstoyDetail: model.isMine
         )
         return (certification, compliment)
     }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -47,16 +47,21 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
         let dateText = model.certificateTime.dateToString(.hangleYearMonthDay)
         let timeText = "인증 시간  " + model.certificateTime.dateToString(.hourMinute)
         let title = "\(model.myNickname)의 기록"
-        let certification = ChallengeHistoryDetail.ViewModel.Challenge(challengeName: model.challengeName,
-                                                                       certificationDateText: dateText,
-                                                                       navigationTitle: title,
-                                                                       certificationImageURL: URL(string: model.certificateImageUrl),
-                                                                       certificationComment: model.certificateComment,
-                                                                       certificationTimeText: timeText)
+        let certification = ChallengeHistoryDetail.ViewModel.Challenge(
+          challengeName: model.challengeName,
+          certificationDateText: dateText,
+          navigationTitle: title,
+          certificationImageURL: URL(string: model.certificateImageUrl),
+          certificationComment: model.certificateComment,
+          certificationTimeText: timeText
+        )
         
         let complimentTitle = "\(model.partnerNickname)이 보낸 칭찬"
-        let compliment = ChallengeHistoryDetail.ViewModel.Compliment(complimentTitle: complimentTitle,
-                                                                     complimentComment: model.complicateComment)
+        let compliment = ChallengeHistoryDetail.ViewModel.Compliment(
+          complimentTitle: complimentTitle,
+          complimentComment: model.complicateComment, 
+          isMyHitstoyDetail: model.isMyHistoryDetail
+        )
         return (certification, compliment)
     }
 

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -13,7 +13,9 @@ import SKPhotoBrowser
 protocol ChallengeHistoryDetailPresentationLogic {
     func presentChallengeDetail(detail: ChallengeHistoryDetail.Model.ChallengeDetail)
     func presentPhoto(imageUrl: String)
-    
+    /// 챌린지 디테일 정보 오류를 보여준다.
+    func presentHistoryDetailError(error: Error)
+
 }
 
 final class ChallengeHistoryDetailPresenter {
@@ -38,7 +40,11 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
         images.append(photo)
         self.viewController?.displayPhoto(photo: .init(images: images))
     }
-    
+
+    func presentHistoryDetailError(error: Error) {
+        self.viewController?.displayToast(viewModel: .init(message: "히스토리 디테일 정보를 가져오는데 실패했습니다."))
+    }
+
     // model -> viewModel
     private func map(_ model: ChallengeHistoryDetail.Model.ChallengeDetail)
     -> (ChallengeHistoryDetail.ViewModel.Challenge,

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -46,7 +46,7 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
     {
         let dateText = model.certificateTime.dateToString(.hangleYearMonthDay)
         let timeText = "인증 시간  " + model.certificateTime.dateToString(.hourMinute)
-        let title = "\(model.isMyHistoryDetail ? model.myNickname : model.partnerNickname)의 기록"
+        let title = "\(model.myNickname)의 기록"
         let certification = ChallengeHistoryDetail.ViewModel.Challenge(
           challengeName: model.challengeName,
           certificationDateText: dateText,

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailPresenter.swift
@@ -46,7 +46,7 @@ extension ChallengeHistoryDetailPresenter: ChallengeHistoryDetailPresentationLog
     {
         let dateText = model.certificateTime.dateToString(.hangleYearMonthDay)
         let timeText = "인증 시간  " + model.certificateTime.dateToString(.hourMinute)
-        let title = "\(model.myNickname)의 기록"
+        let title = "\(model.isMyHistoryDetail ? model.myNickname : model.partnerNickname)의 기록"
         let certification = ChallengeHistoryDetail.ViewModel.Challenge(
           challengeName: model.challengeName,
           certificationDateText: dateText,

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailRouter.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailRouter.swift
@@ -7,11 +7,14 @@
 //
 
 import UIKit
+import PraiseSendScene
 
 @MainActor
 protocol ChallengeHistoryDetailRoutingLogic {
     /// 화면을 닫는다.
     func dismiss()
+    /// 칭찬하기 화면으로 이동한다.
+    func routeToPraiseSendScene()
 }
 
 final class ChallengeHistoryDetailRouter {
@@ -22,5 +25,16 @@ final class ChallengeHistoryDetailRouter {
 extension ChallengeHistoryDetailRouter: ChallengeHistoryDetailRoutingLogic {
     func dismiss() {
         self.viewController?.dismiss(animated: true)
+    }
+  
+    func routeToPraiseSendScene() {
+        guard let dataStore = self.dataStore else {
+            return
+        }
+      
+        let praiseSendScene = PraiseSendSceneFactory().make(
+          with: .init(certificateID: dataStore.detail.id)
+        )
+        self.viewController?.present(praiseSendScene.bottomSheetViewController, animated: true)
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
@@ -66,16 +66,16 @@ public struct ChallengeHistoryDetailConfiguration {
         /// 상대방 닉네임
         public var partnerNickname: String
         /// 본인여부 파악
-        public var isMyHistoryDetail: Bool
+        public var isMine: Bool
       
         public init(
           myNickname: String,
           partnerNickname: String,
-          isMyHistoryDetail: Bool
+          isMine: Bool
         ) {
             self.myNickname = myNickname
             self.partnerNickname = partnerNickname
-            self.isMyHistoryDetail = isMyHistoryDetail
+            self.isMine = isMine
         }
     }
     
@@ -105,7 +105,7 @@ public final class ChallengeHistoryDetailSceneFactory {
                           certificateTime: configuration.detail.certificateTime,
                           partnerNickname: configuration.user.partnerNickname,
                           complicateComment: configuration.detail.complimentComment,
-                          isMyHistoryDetail: configuration.user.isMyHistoryDetail)
+                          isMine: configuration.user.isMine)
         )
         let viewController = ChallengeHistoryDetailViewController(
             interactor: interactor

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
@@ -27,6 +27,8 @@ public struct ChallengeHistoryDetailConfiguration {
     
     /// 챌린지 인증 상세 정보
     public struct ChallengeDetail {
+        /// 챌린지 ID
+        public var challengeID: String
         /// 인증 ID
         public var id: String
         /// 챌린지 이름
@@ -40,12 +42,14 @@ public struct ChallengeHistoryDetailConfiguration {
         /// 칭찬 문구
         public var complimentComment: String?
         
-        public init(id: String,
+        public init(challengeID: String,
+                    id: String,
                     challengeName: String,
                     certificateImageUrl: String,
                     certificateComment: String,
                     certificateTime: Date,
                     complimentComment: String?) {
+            self.challengeID = challengeID
             self.id = id
             self.challengeName = challengeName
             self.certificateImageUrl = certificateImageUrl
@@ -82,15 +86,18 @@ public final class ChallengeHistoryDetailSceneFactory {
     public init() {}
     
     public func make(with configuration: ChallengeHistoryDetailConfiguration) -> ChallengeHistoryDetailScene {
-        
+        let meLocalWorker = MeLocalWorker(localDataSource: LocalDataSource())
+        let challengeDetailNetworkWorker = ChallengeDetailNetworkWorker()
+
         let presenter = ChallengeHistoryDetailPresenter()
         let router = ChallengeHistoryDetailRouter()
-        let worker = ChallengeHistoryDetailWorker()
+        let worker = ChallengeHistoryDetailWorker(meLocalWorker: meLocalWorker, challengeDetailNetworkWorker: challengeDetailNetworkWorker)
         let interactor = ChallengeHistoryDetailInteractor(
             presenter: presenter,
             router: router,
             worker: worker,
-            detail: .init(id: configuration.detail.id,
+            detail: .init(challengeID: configuration.detail.challengeID,
+                          id: configuration.detail.id,
                           challengeName: configuration.detail.challengeName,
                           myNickname: configuration.user.myNickname,
                           certificateImageUrl: configuration.detail.certificateImageUrl,

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailSceneFactory.swift
@@ -61,11 +61,17 @@ public struct ChallengeHistoryDetailConfiguration {
         public var myNickname: String
         /// 상대방 닉네임
         public var partnerNickname: String
-        
-        public init(myNickname: String,
-                    partnerNickname: String) {
+        /// 본인여부 파악
+        public var isMyHistoryDetail: Bool
+      
+        public init(
+          myNickname: String,
+          partnerNickname: String,
+          isMyHistoryDetail: Bool
+        ) {
             self.myNickname = myNickname
             self.partnerNickname = partnerNickname
+            self.isMyHistoryDetail = isMyHistoryDetail
         }
     }
     
@@ -91,7 +97,8 @@ public final class ChallengeHistoryDetailSceneFactory {
                           certificateComment: configuration.detail.certificateComment,
                           certificateTime: configuration.detail.certificateTime,
                           partnerNickname: configuration.user.partnerNickname,
-                          complicateComment: configuration.detail.complimentComment)
+                          complicateComment: configuration.detail.complimentComment,
+                          isMyHistoryDetail: configuration.user.isMyHistoryDetail)
         )
         let viewController = ChallengeHistoryDetailViewController(
             interactor: interactor

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -130,12 +130,34 @@ final class ChallengeHistoryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
+        self.registNotification()
         self.view.setBackgroundDefault()
+    }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    Task {
+        await self.interactor.didLoad()
+    }
+  }
+
+    @objc private func viewDidAppearWithModalDismissed() {
         Task {
+            Loading.shared.showLoadingView()
             await self.interactor.didLoad()
+            Loading.shared.stopLoadingView()
         }
     }
-    
+
+    private func registNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.viewDidAppearWithModalDismissed),
+            name: NSNotification.Name("modal_dismissed"),
+            object: nil
+        )
+    }
+
     // MARK: - Layout
     
     private func setUI() {

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -273,7 +273,7 @@ extension ChallengeHistoryDetailViewController: ChallengeHistoryDetailDisplayLog
             self.complimentLabel.setLineSpacing(8)
         }
         else {
-            self.prasiseButton.isHidden = false
+            self.prasiseButton.isHidden = compliment.isMyHitstoyDetail
             self.complimentTitleLabel.isHidden = true
             self.complimentContentView.isHidden = true
         }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -102,18 +102,19 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         v.isHidden = true
         return v
     }()
-  
+    
     /// 칭찬하기 버튼
     private lazy var prasiseButton: TTPrimaryButtonType = {
-      let v = TTPrimaryButton.create(title: "칭찬하기", .large)
-      v.addAction { [weak self] in
-        Task {
-          try await Task.sleep(nanoseconds: 100000000)
-          await self?.interactor.didTapPraiseButton()
+        let v = TTPrimaryButton.create(title: "칭찬하기", .large)
+        v.addAction { [weak self] in
+            Task {
+                try await Task.sleep(nanoseconds: 100000000)
+                await self?.interactor.didTapPraiseButton()
+            }
         }
-      }
-      v.setIsEnabled(true)
-      return v
+        v.setIsEnabled(true)
+        v.isHidden = true
+        return v
     }()
     
     private lazy var scrollView: UIScrollView = {
@@ -129,18 +130,20 @@ final class ChallengeHistoryDetailViewController: UIViewController {
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.setUI()
         self.registNotification()
         self.view.setBackgroundDefault()
+        self.setUI()
     }
-
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    Task {
-        await self.interactor.didLoad()
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Task {
+            Loading.shared.showLoadingView()
+            await self.interactor.didLoad()
+            Loading.shared.stopLoadingView()
+        }
     }
-  }
-
+    
     @objc private func viewDidAppearWithModalDismissed() {
         Task {
             Loading.shared.showLoadingView()
@@ -148,7 +151,7 @@ final class ChallengeHistoryDetailViewController: UIViewController {
             Loading.shared.stopLoadingView()
         }
     }
-
+    
     private func registNotification() {
         NotificationCenter.default.addObserver(
             self,
@@ -157,22 +160,22 @@ final class ChallengeHistoryDetailViewController: UIViewController {
             object: nil
         )
     }
-
+    
     // MARK: - Layout
     
     private func setUI() {
         let leadingTrailingPadding: Int = 24
         let guide = self.view.safeAreaLayoutGuide
-
+        
         self.scrollContentView.addSubviews(
-          self.dateLabel,
-          self.certificateImageView,
-          self.challengeNameLabel,
-          self.certificationCommentLabel,
-          self.timeLabel,
-          self.complimentTitleLabel,
-          self.complimentContentView,
-          self.prasiseButton
+            self.dateLabel,
+            self.certificateImageView,
+            self.challengeNameLabel,
+            self.certificationCommentLabel,
+            self.timeLabel,
+            self.complimentTitleLabel,
+            self.complimentContentView,
+            self.prasiseButton
         )
         self.scrollView.addSubview(self.scrollContentView)
         
@@ -185,50 +188,50 @@ final class ChallengeHistoryDetailViewController: UIViewController {
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(44)
         }
-
+        
         // ---> 컴포넌트
         self.dateLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(18)
             make.leading.equalToSuperview().offset(leadingTrailingPadding)
             make.trailing.equalToSuperview().inset(leadingTrailingPadding)
         }
-
+        
         let widthHeight = UIScreen.main.bounds.width - CGFloat(leadingTrailingPadding * 2)
         self.certificateImageView.snp.makeConstraints { make in
             make.top.equalTo(self.dateLabel.snp.bottom).offset(21)
             make.width.height.equalTo(widthHeight)
             make.centerX.equalToSuperview()
         }
-
+        
         self.challengeNameLabel.snp.makeConstraints { make in
             make.top.equalTo(self.certificateImageView.snp.bottom).offset(24)
             make.leading.equalTo(leadingTrailingPadding)
         }
-
+        
         self.certificationCommentLabel.snp.makeConstraints { make in
             make.top.equalTo(self.challengeNameLabel.snp.bottom).offset(24)
             make.leading.equalToSuperview().offset(leadingTrailingPadding)
             make.trailing.equalToSuperview().inset(leadingTrailingPadding)
         }
-
+        
         self.timeLabel.snp.makeConstraints { make in
             make.top.equalTo(self.certificationCommentLabel.snp.bottom).offset(20)
             make.leading.equalToSuperview().offset(leadingTrailingPadding)
         }
-
+        
         // ---> 칭찬
         self.complimentTitleLabel.snp.makeConstraints { make in
             make.top.equalTo(self.timeLabel.snp.bottom).offset(33)
             make.leading.equalToSuperview().offset(leadingTrailingPadding)
         }
-
+        
         self.complimentLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(15)
             make.leading.equalToSuperview().offset(10)
             make.trailing.equalToSuperview().inset(10)
             make.bottom.equalToSuperview().inset(15)
         }
-
+        
         self.complimentContentView.snp.makeConstraints { make in
             make.top.equalTo(self.complimentTitleLabel.snp.bottom).offset(8)
             make.leading.equalToSuperview().offset(leadingTrailingPadding)
@@ -237,18 +240,18 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         }
         
         self.prasiseButton.snp.makeConstraints { make in
-          make.leading.equalToSuperview().offset(leadingTrailingPadding)
-          make.trailing.equalToSuperview().inset(leadingTrailingPadding)
-          make.top.equalTo(self.timeLabel.snp.bottom).offset(80)
-          make.bottom.equalToSuperview()
+            make.leading.equalToSuperview().offset(leadingTrailingPadding)
+            make.trailing.equalToSuperview().inset(leadingTrailingPadding)
+            make.top.equalTo(self.timeLabel.snp.bottom).offset(80)
+            make.bottom.equalToSuperview()
         }
-      
+        
         // ---> 스크롤뷰
         self.scrollView.snp.makeConstraints { make in
             make.top.equalTo(self.navigationBar.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
-
+        
         self.scrollContentView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
             make.width.equalToSuperview()

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -102,6 +102,19 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         v.isHidden = true
         return v
     }()
+  
+    /// 칭찬하기 버튼
+    private lazy var prasiseButton: TTPrimaryButtonType = {
+      let v = TTPrimaryButton.create(title: "칭찬하기", .large)
+      v.addAction { [weak self] in
+        Task {
+          try await Task.sleep(nanoseconds: 100000000)
+          await self?.interactor.didTapPraiseButton()
+        }
+      }
+      v.setIsEnabled(true)
+      return v
+    }()
     
     private lazy var scrollView: UIScrollView = {
         let v = UIScrollView()
@@ -129,13 +142,16 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         let leadingTrailingPadding: Int = 24
         let guide = self.view.safeAreaLayoutGuide
 
-        self.scrollContentView.addSubviews(self.dateLabel,
-                                           self.certificateImageView,
-                                           self.challengeNameLabel,
-                                           self.certificationCommentLabel,
-                                           self.timeLabel,
-                                           self.complimentTitleLabel,
-                                           self.complimentContentView)
+        self.scrollContentView.addSubviews(
+          self.dateLabel,
+          self.certificateImageView,
+          self.challengeNameLabel,
+          self.certificationCommentLabel,
+          self.timeLabel,
+          self.complimentTitleLabel,
+          self.complimentContentView,
+          self.prasiseButton
+        )
         self.scrollView.addSubview(self.scrollContentView)
         
         self.view.addSubviews(self.navigationBar,
@@ -197,6 +213,13 @@ final class ChallengeHistoryDetailViewController: UIViewController {
             make.trailing.equalToSuperview().inset(leadingTrailingPadding)
             make.bottom.equalToSuperview()
         }
+        
+        self.prasiseButton.snp.makeConstraints { make in
+          make.leading.equalToSuperview().offset(leadingTrailingPadding)
+          make.trailing.equalToSuperview().inset(leadingTrailingPadding)
+          make.top.equalTo(self.timeLabel.snp.bottom).offset(80)
+          make.bottom.equalToSuperview()
+        }
       
         // ---> 스크롤뷰
         self.scrollView.snp.makeConstraints { make in
@@ -244,11 +267,13 @@ extension ChallengeHistoryDetailViewController: ChallengeHistoryDetailDisplayLog
         if !(compliment.complimentComment?.isEmpty ?? true) {
             self.complimentTitleLabel.isHidden = false
             self.complimentContentView.isHidden = false
+            self.prasiseButton.isHidden = true
             self.complimentTitleLabel.text = compliment.complimentTitle
             self.complimentLabel.text = compliment.complimentComment
             self.complimentLabel.setLineSpacing(8)
         }
         else {
+            self.prasiseButton.isHidden = false
             self.complimentTitleLabel.isHidden = true
             self.complimentContentView.isHidden = true
         }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailViewController.swift
@@ -14,6 +14,7 @@ protocol ChallengeHistoryDetailDisplayLogic: AnyObject {
     func displayCertification(certification: ChallengeHistoryDetail.ViewModel.Challenge)
     func displayCompliment(compliment: ChallengeHistoryDetail.ViewModel.Compliment)
     func displayPhoto(photo: ChallengeHistoryDetail.ViewModel.Photo)
+    func displayToast(viewModel: ChallengeHistoryDetail.ViewModel.Toast)
 }
 
 final class ChallengeHistoryDetailViewController: UIViewController {
@@ -108,7 +109,6 @@ final class ChallengeHistoryDetailViewController: UIViewController {
         let v = TTPrimaryButton.create(title: "칭찬하기", .large)
         v.addAction { [weak self] in
             Task {
-                try await Task.sleep(nanoseconds: 100000000)
                 await self?.interactor.didTapPraiseButton()
             }
         }
@@ -308,5 +308,11 @@ extension ChallengeHistoryDetailViewController: ChallengeHistoryDetailDisplayLog
         let browser = SKPhotoBrowser(photos: photo.images)
         browser.initializePageIndex(0)
         self.present(browser, animated: true, completion: {})
+    }
+
+    func displayToast(viewModel: ChallengeHistoryDetail.ViewModel.Toast) {
+        viewModel.message.unwrap {
+            Toast.shared.makeToast($0)
+        }
     }
 }

--- a/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailWorker.swift
+++ b/Scene/ChallengeHistoryDetailScene/Sources/ChallengeHistoryDetailScene/ChallengeHistoryDetailWorker.swift
@@ -7,7 +7,32 @@
 //
 
 import CoreKit
+import CoreKit
 
-protocol ChallengeHistoryDetailWorkerProtocol {}
+protocol ChallengeHistoryDetailWorkerProtocol {
+    /// 챌린지 상세 조회를 요청한다.
+    func requestChallengeDetailInquiry(challengeID: String) async throws -> ChallengeHistoryDetail.Model.ChallengeDetail
+}
 
-final class ChallengeHistoryDetailWorker: ChallengeHistoryDetailWorkerProtocol {}
+final class ChallengeHistoryDetailWorker: ChallengeHistoryDetailWorkerProtocol {
+    var meLocalWorker: MeLocalWorkerProtocol
+    var challengeDetailNetworkWorker: ChallengeDetailNetworkWorkerProtocol
+
+    init(
+        meLocalWorker: MeLocalWorkerProtocol,
+        challengeDetailNetworkWorker: ChallengeDetailNetworkWorkerProtocol
+    ) {
+        self.meLocalWorker = meLocalWorker
+        self.challengeDetailNetworkWorker = challengeDetailNetworkWorker
+    }
+
+    func requestChallengeDetailInquiry(challengeID: String) async throws -> ChallengeHistoryDetail.Model.ChallengeDetail {
+        let challengeDetailResponse = try await self.challengeDetailNetworkWorker.requestChallengeDetailInquiry(
+            challengeNo: Int(challengeID) ?? 0
+        )
+
+        if let list = challengeDetailResponse.user2CommitList {
+            
+        }
+    }
+}

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
@@ -131,13 +131,13 @@ extension ChallengeHistoryInteractor {
             await self.router.routeToChallengeHistoryDetailScene(title: challenge.name,
                                                                  certificate: myCertificate,
                                                                  nickname: self.worker.myNickname ?? "",
-                                                                 partnerNickname: self.worker.partnerNickname ?? "")
+                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: true)
         }
         else if let partnerCertificate = partnerCertificate {
             await self.router.routeToChallengeHistoryDetailScene(title: challenge.name,
                                                                  certificate: partnerCertificate,
                                                                  nickname: self.worker.partnerNickname ?? "",
-                                                                 partnerNickname: self.worker.myNickname ?? "")
+                                                                 partnerNickname: self.worker.myNickname ?? "", isMyHistoryDetail: false)
         }
     }
 }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
@@ -132,14 +132,14 @@ extension ChallengeHistoryInteractor {
                                                                  title: challenge.name,
                                                                  certificate: myCertificate,
                                                                  nickname: self.worker.myNickname ?? "",
-                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: true)
+                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMine: true)
         }
         else if let partnerCertificate = partnerCertificate {
             await self.router.routeToChallengeHistoryDetailScene(challenge: challenge,
                                                                  title: challenge.name,
                                                                  certificate: partnerCertificate,
                                                                  nickname: self.worker.myNickname ?? "",
-                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: false)
+                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMine: false)
         }
     }
 }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
@@ -136,8 +136,8 @@ extension ChallengeHistoryInteractor {
         else if let partnerCertificate = partnerCertificate {
             await self.router.routeToChallengeHistoryDetailScene(title: challenge.name,
                                                                  certificate: partnerCertificate,
-                                                                 nickname: self.worker.partnerNickname ?? "",
-                                                                 partnerNickname: self.worker.myNickname ?? "", isMyHistoryDetail: false)
+                                                                 nickname: self.worker.myNickname ?? "",
+                                                                 partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: false)
         }
     }
 }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryInteractor.swift
@@ -42,11 +42,11 @@ protocol ChallengeHistoryDataStore: AnyObject {
 
 final class ChallengeHistoryInteractor: ChallengeHistoryDataStore, ChallengeHistoryBusinessLogic {
     var cancellables: Set<AnyCancellable> = []
-    
+
     var presenter: ChallengeHistoryPresentationLogic
     var router: ChallengeHistoryRoutingLogic
     var worker: ChallengeHistoryWorkerProtocol
-    
+
     init(
         presenter: ChallengeHistoryPresentationLogic,
         router: ChallengeHistoryRoutingLogic,
@@ -58,17 +58,17 @@ final class ChallengeHistoryInteractor: ChallengeHistoryDataStore, ChallengeHist
         self.worker = worker
         self.challengeID = challengeID
     }
-    
+
     // MARK: - DataStore
-    
+
     var challengeID: String
-    
+
     var challenge: ChallengeHistory.Model.Challenge?
-    
+
     var myNickname: String? {
         self.worker.myNickname
     }
-    
+
     var partnerNickname: String? {
         self.worker.partnerNickname
     }
@@ -77,17 +77,17 @@ final class ChallengeHistoryInteractor: ChallengeHistoryDataStore, ChallengeHist
 // MARK: - Interactive Business Logic
 
 extension ChallengeHistoryInteractor {
-    
+
     /// 외부 액션 옵저빙
     func observe() {
-        
+
     }
 }
 
 // MARK: Feature (진입)
 
 extension ChallengeHistoryInteractor {
-    
+
     func didAppear() async {
         do {
             let challenge = try await self.worker.requestChallengeDetailInquiry(challengeID: self.challengeID)
@@ -103,7 +103,7 @@ extension ChallengeHistoryInteractor {
 // MARK: Feature (인증)
 
 extension ChallengeHistoryInteractor {
-    
+
     func didTapCertificate() async {
         await self.router.routeToChallengeCertificateScene()
     }
@@ -112,12 +112,12 @@ extension ChallengeHistoryInteractor {
 // MARK: Feature (인증 상세)
 
 extension ChallengeHistoryInteractor {
-    
+
     func didSelectCertificate(certificateID: String) async {
         guard let challenge = self.challenge else {
             return
         }
-        
+
         let myCertificate = challenge.myInfo.certificates
             .filter {
                 $0.id == certificateID
@@ -126,15 +126,17 @@ extension ChallengeHistoryInteractor {
             .filter {
                 $0.id == certificateID
             }.first
-        
+
         if let myCertificate = myCertificate {
-            await self.router.routeToChallengeHistoryDetailScene(title: challenge.name,
+            await self.router.routeToChallengeHistoryDetailScene(challenge: challenge,
+                                                                 title: challenge.name,
                                                                  certificate: myCertificate,
                                                                  nickname: self.worker.myNickname ?? "",
                                                                  partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: true)
         }
         else if let partnerCertificate = partnerCertificate {
-            await self.router.routeToChallengeHistoryDetailScene(title: challenge.name,
+            await self.router.routeToChallengeHistoryDetailScene(challenge: challenge,
+                                                                 title: challenge.name,
                                                                  certificate: partnerCertificate,
                                                                  nickname: self.worker.myNickname ?? "",
                                                                  partnerNickname: self.worker.partnerNickname ?? "", isMyHistoryDetail: false)
@@ -145,23 +147,23 @@ extension ChallengeHistoryInteractor {
 // MARK: Feature (챌린지 그만두기)
 
 extension ChallengeHistoryInteractor {
-    
+
     func didTapOptionButton() async {
         await self.presenter.presentOptionPopup()
     }
-    
+
     func didTapOptionPopupQuitButton() async {
         await self.presenter.presentQuitPopup()
     }
-    
+
     func didTapQuitPopupCancelButton() async {
         await self.presenter.dismissQuitPopup()
     }
-    
+
     func didTapQuitPopupBackground() async {
         await self.presenter.dismissQuitPopup()
     }
-    
+
     func didTapQuitPopupQuitButton() async {
         do {
             try await self.worker.requestChallengeQuit(challengeID: self.challengeID)
@@ -177,7 +179,7 @@ extension ChallengeHistoryInteractor {
 // MARK: Feature (뒤로가기)
 
 extension ChallengeHistoryInteractor {
-    
+
     func didTapBackButton() async {
         await self.router.dismiss()
     }
@@ -188,5 +190,5 @@ extension ChallengeHistoryInteractor {
 // MARK: UseCase ()
 
 extension ChallengeHistoryInteractor {
-    
+
 }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
@@ -35,13 +35,18 @@ extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
                                             nickname: String,
                                             partnerNickname: String) {
         
-        let fac = ChallengeHistoryDetailSceneFactory().make(with: .init(detail: .init(id: certificate.id,
-                                                                                      challengeName: title,
-                                                                                      certificateImageUrl: certificate.certificateImageUrl,
-                                                                                      certificateComment: certificate.certificateComment,
-                                                                                      certificateTime: certificate.certificateTime,
-                                                                                      complimentComment: certificate.complimentComment),
-                                                                        user: .init(myNickname: nickname, partnerNickname: partnerNickname)))
+        let fac = ChallengeHistoryDetailSceneFactory().make(
+          with: .init(
+            detail: .init(
+              id: certificate.id,
+              challengeName: title,
+              certificateImageUrl: certificate.certificateImageUrl,
+              certificateComment: certificate.certificateComment,
+              certificateTime: certificate.certificateTime,
+              complimentComment: certificate.complimentComment),
+            user: .init(myNickname: nickname, partnerNickname: partnerNickname)
+          )
+        )
         let vc = fac.viewController
         vc.modalPresentationStyle = .fullScreen
         self.viewController?.present(vc, animated: true)

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
@@ -19,7 +19,7 @@ protocol ChallengeHistoryRoutingLogic {
     func routeToChallengeHistoryDetailScene(title: String,
                                             certificate: ChallengeHistory.Model.Certificate,
                                             nickname: String,
-                                            partnerNickname: String)
+                                            partnerNickname: String, isMyHistoryDetail: Bool)
     /// 화면을 닫는다.
     func dismiss()
 }
@@ -30,11 +30,13 @@ final class ChallengeHistoryRouter {
 }
 
 extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
-    func routeToChallengeHistoryDetailScene(title: String,
-                                            certificate: ChallengeHistory.Model.Certificate,
-                                            nickname: String,
-                                            partnerNickname: String) {
-        
+    func routeToChallengeHistoryDetailScene(
+      title: String,
+      certificate: ChallengeHistory.Model.Certificate,
+      nickname: String,
+      partnerNickname: String,
+      isMyHistoryDetail: Bool
+    ) {
         let fac = ChallengeHistoryDetailSceneFactory().make(
           with: .init(
             detail: .init(
@@ -44,7 +46,7 @@ extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
               certificateComment: certificate.certificateComment,
               certificateTime: certificate.certificateTime,
               complimentComment: certificate.complimentComment),
-            user: .init(myNickname: nickname, partnerNickname: partnerNickname)
+            user: .init(myNickname: nickname, partnerNickname: partnerNickname, isMyHistoryDetail: isMyHistoryDetail)
           )
         )
         let vc = fac.viewController

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
@@ -16,7 +16,7 @@ protocol ChallengeHistoryRoutingLogic {
     /// 인증하기 화면으로 이동한다.
     func routeToChallengeCertificateScene()
     /// 인증 상세 화면으로 이동한다.
-    func routeToChallengeHistoryDetailScene(title: String,
+    func routeToChallengeHistoryDetailScene(challenge: ChallengeHistory.Model.Challenge, title: String,
                                             certificate: ChallengeHistory.Model.Certificate,
                                             nickname: String,
                                             partnerNickname: String, isMyHistoryDetail: Bool)
@@ -31,30 +31,32 @@ final class ChallengeHistoryRouter {
 
 extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
     func routeToChallengeHistoryDetailScene(
-      title: String,
-      certificate: ChallengeHistory.Model.Certificate,
-      nickname: String,
-      partnerNickname: String,
-      isMyHistoryDetail: Bool
+        challenge: ChallengeHistory.Model.Challenge,
+        title: String,
+        certificate: ChallengeHistory.Model.Certificate,
+        nickname: String,
+        partnerNickname: String,
+        isMyHistoryDetail: Bool
     ) {
         let fac = ChallengeHistoryDetailSceneFactory().make(
-          with: .init(
-            detail: .init(
-              id: certificate.id,
-              challengeName: title,
-              certificateImageUrl: certificate.certificateImageUrl,
-              certificateComment: certificate.certificateComment,
-              certificateTime: certificate.certificateTime,
-              complimentComment: certificate.complimentComment),
-            user: .init(myNickname: nickname, partnerNickname: partnerNickname, isMyHistoryDetail: isMyHistoryDetail)
-          )
+            with: .init(
+                detail: .init(
+                    challengeID: challenge.id,
+                    id: certificate.id,
+                    challengeName: title,
+                    certificateImageUrl: certificate.certificateImageUrl,
+                    certificateComment: certificate.certificateComment,
+                    certificateTime: certificate.certificateTime,
+                    complimentComment: certificate.complimentComment),
+                user: .init(myNickname: nickname, partnerNickname: partnerNickname, isMyHistoryDetail: isMyHistoryDetail)
+            )
         )
         let vc = fac.viewController
         vc.modalPresentationStyle = .fullScreen
         self.viewController?.present(vc, animated: true)
     }
-    
-    
+
+
     func routeToChallengeCertificateScene() {
         guard let dataStore = self.dataStore else {
             return
@@ -64,7 +66,7 @@ extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
         )
         self.viewController?.present(challengeCertificateScene.bottomSheetViewController, animated: true)
     }
-    
+
     func dismiss() {
         self.viewController?.navigationController?.popViewController(animated: true)
     }

--- a/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
+++ b/Scene/ChallengeHistoryScene/Sources/ChallengeHistoryScene/ChallengeHistoryRouter.swift
@@ -19,7 +19,7 @@ protocol ChallengeHistoryRoutingLogic {
     func routeToChallengeHistoryDetailScene(challenge: ChallengeHistory.Model.Challenge, title: String,
                                             certificate: ChallengeHistory.Model.Certificate,
                                             nickname: String,
-                                            partnerNickname: String, isMyHistoryDetail: Bool)
+                                            partnerNickname: String, isMine: Bool)
     /// 화면을 닫는다.
     func dismiss()
 }
@@ -36,7 +36,7 @@ extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
         certificate: ChallengeHistory.Model.Certificate,
         nickname: String,
         partnerNickname: String,
-        isMyHistoryDetail: Bool
+        isMine: Bool
     ) {
         let fac = ChallengeHistoryDetailSceneFactory().make(
             with: .init(
@@ -48,7 +48,7 @@ extension ChallengeHistoryRouter: ChallengeHistoryRoutingLogic {
                     certificateComment: certificate.certificateComment,
                     certificateTime: certificate.certificateTime,
                     complimentComment: certificate.complimentComment),
-                user: .init(myNickname: nickname, partnerNickname: partnerNickname, isMyHistoryDetail: isMyHistoryDetail)
+                user: .init(myNickname: nickname, partnerNickname: partnerNickname, isMine: isMine)
             )
         )
         let vc = fac.viewController

--- a/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
@@ -22,12 +22,6 @@ protocol HomeBusinessLogic {
     func didTapChallengeCompletedPopupConfirmButton() async
     /// 챌린지 완료하기 버튼 클릭
     func didTapChallengeCompleteButton() async
-    /// 둘다 인증 팝업의 배경 클릭
-    func didTapBothCertificationPopupBackground() async
-    /// 둘다 인증 팝업의 괜찮아요(no) 버튼 클릭
-    func didTapBothCertificationPopupNoOption() async
-    /// 둘다 인증 팝업의 칭찬하기(yes) 버튼 클릭
-    func didTapBothCertificationPopupYesOption() async
     /// 내 칭찬 문구 클릭
     func didTapMyComplimentCommnet() async
     /// 내 꽃 클릭
@@ -130,11 +124,6 @@ extension HomeInteractor {
                 case let .inProgress(inProgress):
                     await self.presenter.presentChallengeInProgress(challenge: challenge)
                     
-                    if inProgress == .bothCertificated(.uncomfirmed) {
-                        self.worker.bothCertificationConfirmed = true
-                        await self.presenter.presentBothCertificationPopup()
-                    }
-                    
                 case let .completed(completed):
                     await self.presenter.presentChallengeCompleted(challenge: challenge)
                     
@@ -217,23 +206,8 @@ extension HomeInteractor {
 
 extension HomeInteractor {
     
-    func didTapBothCertificationPopupBackground() async {
-        await self.presenter.dismissBothCertificationPopup()
-    }
-    
-    func didTapBothCertificationPopupNoOption() async {
-        await self.presenter.dismissBothCertificationPopup()
-    }
-    
-    func didTapBothCertificationPopupYesOption() async {
-        await self.presenter.dismissBothCertificationPopup()
-        await self.router.routeToPraiseSendScene()
-    }
-    
     func didTapMyComplimentCommnet() async {
-        if self.challenge?.partnerInfo.todayCert?.complimentComment?.isEmpty ?? true {
-            await self.router.routeToPraiseSendScene()
-        }
+      await self.router.routeToPartnerHistoryDetailScene(title: "", certificate: .init(id: ""), nickname: "", partnerNickname: "")
     }
 }
 

--- a/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
@@ -23,7 +23,7 @@ protocol HomeBusinessLogic {
     /// 챌린지 완료하기 버튼 클릭
     func didTapChallengeCompleteButton() async
     /// 내 칭찬 문구 클릭
-    func didTapMyComplimentCommnet() async
+    func didTapMyComplimentComment() async
     /// 내 꽃 클릭
     func didTapMyFlower() async
     /// 찌르기 버튼 클릭
@@ -205,9 +205,23 @@ extension HomeInteractor {
 // MARK: Feature (칭찬)
 
 extension HomeInteractor {
-  // TODO: - 값 넣어줘야함
-    func didTapMyComplimentCommnet() async {
-      await self.router.routeToPartnerHistoryDetailScene(title: "", certificate: .init(id: ""), nickname: "", partnerNickname: "")
+  func didTapMyComplimentComment() async {
+      guard let challenge = self.challenge else {
+          return
+      }
+      
+      await self.router.routeToPartnerHistoryDetailScene(
+        title: challenge.name ?? "",
+        certificate: .init(
+          id: challenge.partnerInfo.todayCert?.id ?? "",
+          complimentComment: challenge.partnerInfo.todayCert?.complimentComment,
+          imageURL: challenge.partnerInfo.todayCert?.imageURL ?? "",
+          time: challenge.partnerInfo.todayCert?.time ?? "",
+          contents: challenge.partnerInfo.todayCert?.contents ?? ""
+        ),
+        nickname: challenge.myInfo.nickname,
+        partnerNickname: challenge.partnerInfo.nickname
+      )
     }
 }
 

--- a/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeInteractor.swift
@@ -205,7 +205,7 @@ extension HomeInteractor {
 // MARK: Feature (칭찬)
 
 extension HomeInteractor {
-    
+  // TODO: - 값 넣어줘야함
     func didTapMyComplimentCommnet() async {
       await self.router.routeToPartnerHistoryDetailScene(title: "", certificate: .init(id: ""), nickname: "", partnerNickname: "")
     }

--- a/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
@@ -65,6 +65,12 @@ enum Home {
         struct Certificate: Equatable {
             /// 인증 ID
             var id: String
+//            /// 인증 사진
+//            var certificateImageUrl: String
+//            /// 인증 소감
+//            var certificateComment: String
+//            /// 입력 시간
+//            var certificateTime: Date
             /// 칭찬 문구
             var complimentComment: String?
         }
@@ -259,22 +265,6 @@ enum Home {
                     var complimentCommentText: String
                 }
             }
-            
-            /// 둘다 인증 팝업
-            struct BothCertificationPopupViewModel {
-                var show: (UIImage)?
-                var dismiss: ()?
-                
-                /// 타이틀
-                static let title: String = "모두 인증 완료"
-                /// 메세지
-                static let message: String = "서로 인증을 완료했어요!\n 짝꿍에게 응원 한마디를 남겨요"
-                /// 아니요
-                static let noOptionText: String = "괜찮아요"
-                /// 네 옵션
-                static let yesOptionText: String = "칭찬하기"
-            }
-
         }
         
 

--- a/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeModels.swift
@@ -65,14 +65,14 @@ enum Home {
         struct Certificate: Equatable {
             /// 인증 ID
             var id: String
-//            /// 인증 사진
-//            var certificateImageUrl: String
-//            /// 인증 소감
-//            var certificateComment: String
-//            /// 입력 시간
-//            var certificateTime: Date
             /// 칭찬 문구
             var complimentComment: String?
+            /// 인증 Image URL
+            var imageURL: String
+            /// 인증 시간
+            var time: String
+            /// 인증 내용
+            var contents: String
         }
 
         /// 성장도

--- a/Scene/HomeScene/Sources/HomeScene/HomePresenter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomePresenter.swift
@@ -23,10 +23,6 @@ protocol HomePresentationLogic {
     func presentChallengeAfterStartDate(challenge: Home.Model.Challenge)
     /// 챌린지 진행중 화면을 보여준다.
     func presentChallengeInProgress(challenge: Home.Model.Challenge)
-    /// 둘다 인증 팝업을 보여준다.
-    func presentBothCertificationPopup()
-    /// 둘다 인증 팝업을 닫는다.
-    func dismissBothCertificationPopup()
     /// 챌린지 완료 화면을 보여준다.
     func presentChallengeCompleted(challenge: Home.Model.Challenge)
     /// 챌린지 완료 팝업을 보여준다.
@@ -84,14 +80,6 @@ extension HomePresenter: HomePresentationLogic {
         self.viewController?.displayChallengeInProgressViewModel(
             viewModel: challenge.toChallengeInProgressViewModel()
         )
-    }
-    
-    func presentBothCertificationPopup() {
-        self.viewController?.displayBothCertificationViewModel(viewModel: .init(show: (.asset(.icon_all_verified)!)))
-    }
-    
-    func dismissBothCertificationPopup() {
-        self.viewController?.displayBothCertificationViewModel(viewModel: .init(dismiss: ()))
     }
     
     func presentChallengeCompleted(challenge: Home.Model.Challenge) {

--- a/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
@@ -45,7 +45,7 @@ extension HomeRouter: HomeRoutingLogic {
         challengeEssentialInfoInputViewController.hidesBottomBarWhenPushed = true
         self.viewController?.navigationController?.pushViewController(challengeEssentialInfoInputViewController, animated: true)
     }
-    
+
     func routeToChallengeConfirmScene(entryPoint: String) {
         guard let dataStore = self.dataStore else {
             return
@@ -62,35 +62,36 @@ extension HomeRouter: HomeRoutingLogic {
         challengeConfirmViewController.hidesBottomBarWhenPushed = true
         self.viewController?.navigationController?.pushViewController(challengeConfirmViewController, animated: true)
     }
-    
+
     func routeToPartnerHistoryDetailScene(title: String,
                                           certificate: Home.Model.Certificate,
                                           nickname: String,
                                           partnerNickname: String) {
-      guard let dataStore = self.dataStore else {
-          return
-      }
-      
-      let historyDetailScene = ChallengeHistoryDetailSceneFactory().make(with: .init(
-        detail: .init(
-          id: certificate.id,
-          challengeName: dataStore.challenge?.name ?? "",
-          certificateImageUrl: certificate.imageURL,
-          certificateComment: certificate.contents,
-          certificateTime: dataStore.challenge?.partnerInfo.todayCert?.time.fullStringDate(.iso) ?? Date(),
-          complimentComment: certificate.complimentComment
-        ), user: .init(
-          myNickname: dataStore.challenge?.myInfo.nickname ?? "",
-          partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "",
-          isMyHistoryDetail: false
-        )
-      ))
-      
-      let vc = historyDetailScene.viewController
-      vc.modalPresentationStyle = .fullScreen
-      self.viewController?.present(vc, animated: true)
+        guard let dataStore = self.dataStore else {
+            return
+        }
+
+        let historyDetailScene = ChallengeHistoryDetailSceneFactory().make(with: .init(
+            detail: .init(
+                challengeID: dataStore.challenge?.id ?? "",
+                id: certificate.id,
+                challengeName: dataStore.challenge?.name ?? "",
+                certificateImageUrl: certificate.imageURL,
+                certificateComment: certificate.contents,
+                certificateTime: dataStore.challenge?.partnerInfo.todayCert?.time.fullStringDate(.iso) ?? Date(),
+                complimentComment: certificate.complimentComment
+            ), user: .init(
+                myNickname: dataStore.challenge?.myInfo.nickname ?? "",
+                partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "",
+                isMyHistoryDetail: false
+            )
+        ))
+
+        let vc = historyDetailScene.viewController
+        vc.modalPresentationStyle = .fullScreen
+        self.viewController?.present(vc, animated: true)
     }
-    
+
     func routeToChallengeCertificateScene() {
         guard let dataStore = self.dataStore else {
             return
@@ -100,7 +101,7 @@ extension HomeRouter: HomeRoutingLogic {
         )
         self.viewController?.present(challengeCertificateScene.bottomSheetViewController, animated: true)
     }
-    
+
     func routeToNudgeSendScene() {
         guard let dataStore = self.dataStore else {
             return
@@ -110,7 +111,7 @@ extension HomeRouter: HomeRoutingLogic {
         )
         self.viewController?.present(nudgeSendScene.bottomSheetViewController, animated: true)
     }
-    
+
     func routeToChallengeHistoryScene() {
         guard let dataStore = self.dataStore else {
             return
@@ -122,13 +123,13 @@ extension HomeRouter: HomeRoutingLogic {
         challengeHistoryViewController.hidesBottomBarWhenPushed = true
         self.viewController?.navigationController?.pushViewController(challengeHistoryViewController, animated: true)
     }
-    
+
     func routeToGuideScene() {
         guard let url = URL(string: "https://two2too2.github.io/") else {
             return
         }
         let safariViewController = SFSafariViewController(url: url)
-        
+
         self.viewController?.present(safariViewController, animated: true, completion: nil)
     }
 }

--- a/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
@@ -63,8 +63,6 @@ extension HomeRouter: HomeRoutingLogic {
         self.viewController?.navigationController?.pushViewController(challengeConfirmViewController, animated: true)
     }
     
-  
-    // TODO: - 값 넣어줘야함
     func routeToPartnerHistoryDetailScene(title: String,
                                           certificate: Home.Model.Certificate,
                                           nickname: String,
@@ -77,16 +75,20 @@ extension HomeRouter: HomeRoutingLogic {
         detail: .init(
           id: certificate.id,
           challengeName: dataStore.challenge?.name ?? "",
-          certificateImageUrl: "",
-          certificateComment: "",
-          certificateTime: Date(),
-          complimentComment: ""
+          certificateImageUrl: certificate.imageURL,
+          certificateComment: certificate.contents,
+          certificateTime: dataStore.challenge?.partnerInfo.todayCert?.time.fullStringDate(.iso) ?? Date(),
+          complimentComment: certificate.complimentComment
         ), user: .init(
           myNickname: dataStore.challenge?.myInfo.nickname ?? "",
           partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "",
           isMyHistoryDetail: false
         )
       ))
+      
+      let vc = historyDetailScene.viewController
+      vc.modalPresentationStyle = .fullScreen
+      self.viewController?.present(vc, animated: true)
     }
     
     func routeToChallengeCertificateScene() {

--- a/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
@@ -64,6 +64,7 @@ extension HomeRouter: HomeRoutingLogic {
     }
     
   
+    // TODO: - 값 넣어줘야함
     func routeToPartnerHistoryDetailScene(title: String,
                                           certificate: Home.Model.Certificate,
                                           nickname: String,
@@ -82,7 +83,9 @@ extension HomeRouter: HomeRoutingLogic {
           complimentComment: ""
         ), user: .init(
           myNickname: dataStore.challenge?.myInfo.nickname ?? "",
-          partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "")
+          partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "",
+          isMyHistoryDetail: false
+        )
       ))
     }
     

--- a/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
@@ -83,7 +83,7 @@ extension HomeRouter: HomeRoutingLogic {
             ), user: .init(
                 myNickname: dataStore.challenge?.myInfo.nickname ?? "",
                 partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "",
-                isMyHistoryDetail: false
+                isMine: false
             )
         ))
 

--- a/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeRouter.swift
@@ -7,9 +7,9 @@
 //
 
 import NudgeSendScene
-import PraiseSendScene
 import ChallengeCertificateScene
 import ChallengeHistoryScene
+import ChallengeHistoryDetailScene
 import ChallengeEssentialInfoInputScene
 import ChallengeConfirmScene
 import SafariServices
@@ -21,8 +21,8 @@ protocol HomeRoutingLogic {
     func routeToChallengeEssentialInfoInputScene()
     /// 챌린지 정보 확인 화면으로 이동한다.
     func routeToChallengeConfirmScene(entryPoint: String)
-    /// 칭찬하기 화면으로 이동한다.
-    func routeToPraiseSendScene()
+    /// 상대방 챌린지 히스토리 디테일 화면으로 이동한다.
+    func routeToPartnerHistoryDetailScene(title: String, certificate: Home.Model.Certificate, nickname: String, partnerNickname: String)
     /// 인증하기 화면으로 이동한다.
     func routeToChallengeCertificateScene()
     /// 찌르기 화면으로 이동한다.
@@ -39,7 +39,6 @@ final class HomeRouter {
 }
 
 extension HomeRouter: HomeRoutingLogic {
-    
     func routeToChallengeEssentialInfoInputScene() {
         let challengeEssentialInfoInputScene = ChallengeEssentialInfoInputSceneFactory().make(with: .init())
         let challengeEssentialInfoInputViewController = challengeEssentialInfoInputScene.viewController
@@ -64,14 +63,27 @@ extension HomeRouter: HomeRoutingLogic {
         self.viewController?.navigationController?.pushViewController(challengeConfirmViewController, animated: true)
     }
     
-    func routeToPraiseSendScene() {
-        guard let dataStore = self.dataStore else {
-            return
-        }
-        let praiseSendScene = PraiseSendSceneFactory().make(
-            with: .init(certificateID: dataStore.challenge?.partnerInfo.todayCert?.id ?? "")
-        )
-        self.viewController?.present(praiseSendScene.bottomSheetViewController, animated: true)
+  
+    func routeToPartnerHistoryDetailScene(title: String,
+                                          certificate: Home.Model.Certificate,
+                                          nickname: String,
+                                          partnerNickname: String) {
+      guard let dataStore = self.dataStore else {
+          return
+      }
+      
+      let historyDetailScene = ChallengeHistoryDetailSceneFactory().make(with: .init(
+        detail: .init(
+          id: certificate.id,
+          challengeName: dataStore.challenge?.name ?? "",
+          certificateImageUrl: "",
+          certificateComment: "",
+          certificateTime: Date(),
+          complimentComment: ""
+        ), user: .init(
+          myNickname: dataStore.challenge?.myInfo.nickname ?? "",
+          partnerNickname: dataStore.challenge?.partnerInfo.nickname ?? "")
+      ))
     }
     
     func routeToChallengeCertificateScene() {

--- a/Scene/HomeScene/Sources/HomeScene/HomeViewController.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeViewController.swift
@@ -415,7 +415,7 @@ extension HomeViewController: ChallengeInProgressViewDelegate{
     
     func didTapMyFlowerEmptySpeechBubbleView() {
         Task {
-            await self.interactor.didTapMyComplimentCommnet()
+            await self.interactor.didTapMyComplimentComment()
         }
     }
     

--- a/Scene/HomeScene/Sources/HomeScene/HomeViewController.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeViewController.swift
@@ -17,7 +17,6 @@ protocol HomeDisplayLogic: AnyObject {
     func displayChallengeAfterStartDateViewModel(viewModel: Home.ViewModel.ChallengeAfterStartDateViewModel)
     func displayChallengeInProgressViewModel(viewModel: Home.ViewModel.ChallengeInProgressViewModel)
     func displayChallengeCompletedViewModel(viewModel: Home.ViewModel.ChallengeCompletedViewModel)
-    func displayBothCertificationViewModel(viewModel: Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel)
     func displayCompletedViewModel(viewModel: Home.ViewModel.ChallengeCompletedViewModel.CompletedPopupViewModel)
     func displayToast(viewModel: Home.ViewModel.Toast)
 }
@@ -284,59 +283,6 @@ extension HomeViewController: HomeDisplayLogic {
         self.displayWithClearAndAnimation { [weak self] in
             self?.completedView.configure(viewModel: viewModel)
             self?.completedView.isHidden = false
-        }
-    }
-    
-    func displayBothCertificationViewModel(viewModel: Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel) {
-        self.displayWithAnimation { [weak self] in
-            viewModel.show.unwrap {
-                let popupContentView = UIView()
-                let imageView = UIImageView()
-                imageView.image = $0
-                imageView.contentMode = .scaleAspectFit
-                popupContentView.addSubview(imageView)
-                imageView.snp.makeConstraints { make in
-                    make.edges.equalToSuperview()
-                }
-                
-                let popupView = TTPopup()
-                popupView.configure(title: Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel.title,
-                                    resultView: popupContentView,
-                                    description: Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel.message,
-                                    buttonTitles: [
-                                        Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel.noOptionText,
-                                        Home.ViewModel.ChallengeInProgressViewModel.BothCertificationPopupViewModel.yesOptionText
-                                    ])
-                
-                popupView.didTapLeftButton {
-                    Task {
-                        await self?.interactor.didTapBothCertificationPopupNoOption()
-                    }
-                }
-                
-                popupView.didTapRightButton {
-                    Task {
-                        await self?.interactor.didTapBothCertificationPopupYesOption()
-                    }
-                }
-                
-                popupView.didTapBackground {
-                    Task {
-                        await self?.interactor.didTapBothCertificationPopupBackground()
-                    }
-                }
-                
-                self?.bothCertificationPopupView = popupView
-                
-                if let bothCertificationPopupView = self?.bothCertificationPopupView {
-                    self?.view.addSubview(bothCertificationPopupView)
-                }
-            }
-            
-            viewModel.dismiss.unwrap {
-                self?.bothCertificationPopupView?.removeFromSuperview()
-                self?.bothCertificationPopupView = nil
-            }
         }
     }
     

--- a/Scene/HomeScene/Sources/HomeScene/HomeWorker.swift
+++ b/Scene/HomeScene/Sources/HomeScene/HomeWorker.swift
@@ -184,7 +184,7 @@ final class HomeWorker: HomeWorkerProtocol {
         )
         
         if let commit = commit {
-            userInfo.todayCert = .init(id: String(commit.commitNo), complimentComment: commit.partnerComment)
+            userInfo.todayCert = .init(id: String(commit.commitNo), complimentComment: commit.partnerComment, imageURL: commit.photoUrl, time: commit.createdAt, contents: commit.text)
         }
         
         userInfo.certCount = commitCount ?? 0


### PR DESCRIPTION
## 개요
- 칭찬하기 기능 Flow가 수정됨에 따라 코드 수정 및 기능 추가를 합니다.

## 변경사항
- 모두 인증완료 팝업을 삭제했습니다.
- 히스토리 디테일에 칭찬하기 버튼을 추가했습니다.
- 칭찬한 후에 이전 화면에 칭찬한 문구가 보이도록 수정했습니다.
- 홈 -> 칭찬하기 눌렀을 때 상대방 히스토리 디테일로 가도록 수정했습니다.

## 스크린샷

https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/9f8540fc-689f-41bf-9ebf-ab65730ea9f8


