### PR TITLE
SE에서 닉네임 변경 입력 시 키보드에 의해 화면 짤리는 문제 해결

### DIFF
--- a/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
+++ b/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
@@ -191,6 +191,12 @@ extension ChangeNicknameViewController: KeyboardDelegate {
     
     func willHideKeyboard(duration: Double) {
         UIView.animate(withDuration: duration) {
+            if UIDevice.current.deviceType == .default {
+                self.descriptionLabel.snp.updateConstraints { make in
+                    make.bottom.equalTo(self.nicknameTextField.snp.top).offset(-40)
+                }
+            }
+
             self.changeButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
             }

--- a/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
+++ b/Scene/MyInfoScene/Sources/ChangeNicknameScene/ChangeNicknameViewController.swift
@@ -176,6 +176,12 @@ extension ChangeNicknameViewController: KeyboardDelegate {
     func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
         
         UIView.animate(withDuration: duration) {
+            if UIDevice.current.deviceType == .default {
+                self.descriptionLabel.snp.updateConstraints { make in
+                    make.bottom.equalTo(self.nicknameTextField.snp.top).offset(-10)
+                }
+            }
+
             self.changeButton.snp.updateConstraints { make in
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardFrame.height + 20)
             }


### PR DESCRIPTION
## 개요
- SE에서 닉네임 변경 입력 시 키보드에 의해 TextField가 가려지는 현상 해결합니다.

## 변경사항
- 레이아웃을 수정하여 텍스트필드가 보이도록 합니다.

## 스크린샷

### iPhone SE
|변경전|변경후|
|:---:|:---:|
|![IMG_7081](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/3273784e-c5e3-44b8-a299-71160c10d215)|![IMG_7083](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/c5f41d81-d789-42a4-8668-1ecdc0cd21d7)|!

### iPhone 12 Pro

![IMG_0766](https://github.com/mash-up-kr/TwoToo_iOS/assets/52434820/a0612531-f67d-43f6-8268-77fbe3fe125c)

