### PR TITLE
SE 기기에서 바텀시트 올라갈 때 버튼 가리는 이슈 해결

### DIFF
--- a/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/Layout/SelfSizingScrollView.swift
+++ b/Core/DesignSystem/Sources/DesignSystem/Sources/Component/BottomSheet/Layout/SelfSizingScrollView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 public final class SelfSizingScrollView: UIScrollView {
-    private var maxHeight: CGFloat = UIScreen.main.bounds.height * 0.67
+    private var maxHeight: CGFloat = UIScreen.main.bounds.height
     
     public override var intrinsicContentSize: CGSize {
         CGSize(width: contentSize.width,
@@ -20,9 +20,9 @@ public final class SelfSizingScrollView: UIScrollView {
         invalidateIntrinsicContentSize()
     }
     
-    public convenience init(maxHeight: CGFloat) {
+    public convenience init(maxHeightRatio: CGFloat = 0.67) {
         self.init()
-        self.maxHeight = maxHeight
+        self.maxHeight *= maxHeightRatio
     }
     
     public override init(frame: CGRect) {

--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
@@ -211,13 +211,6 @@ extension ChallengeCertificateViewController: TTTextViewDelegate,
                 scrollOffset += 14
             }
             self.backScrollView.contentOffset.y = scrollOffset
-//            let bottomOffset = keyboardFrame.height + 14
-//            self.commitButton.snp.remakeConstraints { make in
-//                make.leading.equalToSuperview().offset(24)
-//                make.trailing.equalToSuperview().inset(24)
-//                make.height.equalTo(57)
-//                make.bottom.equalTo(self.view.snp.bottom).inset(bottomOffset)
-//            }
             self.view.layoutIfNeeded()
         }
     }

--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
@@ -25,6 +25,10 @@ protocol ChallengeCertificateDisplayLogic: AnyObject {
 final class ChallengeCertificateViewController: UIViewController, BottomSheetViewController {
     var interactor: ChallengeCertificateBusinessLogic
     
+    private var isCheckDeviceSE: Bool {
+        UIDevice.current.deviceType == .default
+    }
+    
     init(interactor: ChallengeCertificateBusinessLogic) {
         self.interactor = interactor
         super.init(nibName: nil, bundle: nil)
@@ -102,7 +106,7 @@ final class ChallengeCertificateViewController: UIViewController, BottomSheetVie
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let heightRatio = UIDevice.current.deviceType == .default ? 0.85 : 0.72
+        let heightRatio = UIDevice.current.deviceType == .default ? 0.87 : 0.72
         let v = SelfSizingScrollView(maxHeightRatio: heightRatio)
         v.delegate = self
         v.addTapAction { [weak self] in
@@ -142,10 +146,13 @@ final class ChallengeCertificateViewController: UIViewController, BottomSheetVie
             make.centerX.equalToSuperview()
         }
         
+        let leadingTrailningInset = isCheckDeviceSE ? 5 : 0
+        let height = isCheckDeviceSE ? 300 : 312
         self.commitPhotoView.snp.makeConstraints { make in
             make.top.equalTo(self.titleLabel.snp.bottom).offset(16)
-            make.leading.trailing.equalToSuperview()
-            make.height.equalTo(self.commitPhotoView.snp.width)
+            make.leading.equalToSuperview().offset(leadingTrailningInset)
+            make.trailing.equalToSuperview().offset(-leadingTrailningInset)
+            make.height.equalTo(height)
         }
         
         self.commentTextView.snp.makeConstraints { make in
@@ -154,11 +161,12 @@ final class ChallengeCertificateViewController: UIViewController, BottomSheetVie
             make.height.equalTo(85)
         }
         
+        let bottomOffset = isCheckDeviceSE ? 4 : 0
         self.commitButton.snp.makeConstraints { make in
             make.top.equalTo(self.commentTextView.snp.bottom).offset(29)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(57)
-            make.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().inset(bottomOffset)
         }
         
         self.scrollSizeFitView.snp.makeConstraints { make in
@@ -198,14 +206,18 @@ extension ChallengeCertificateViewController: TTTextViewDelegate,
             self.scrollSizeFitView.snp.updateConstraints { make in
                 make.bottom.equalToSuperview().inset(keyboardFrame.height)
             }
-            self.backScrollView.contentOffset.y = keyboardFrame.height
-            let bottomOffset = keyboardFrame.height + 14
-            self.commitButton.snp.remakeConstraints { make in
-                make.leading.equalToSuperview().offset(24)
-                make.trailing.equalToSuperview().inset(24)
-                make.height.equalTo(57)
-                make.bottom.equalTo(self.view.snp.bottom).inset(bottomOffset)
+            var scrollOffset = keyboardFrame.height
+            if UIDevice.current.deviceType == .default {
+                scrollOffset += 14
             }
+            self.backScrollView.contentOffset.y = scrollOffset
+//            let bottomOffset = keyboardFrame.height + 14
+//            self.commitButton.snp.remakeConstraints { make in
+//                make.leading.equalToSuperview().offset(24)
+//                make.trailing.equalToSuperview().inset(24)
+//                make.height.equalTo(57)
+//                make.bottom.equalTo(self.view.snp.bottom).inset(bottomOffset)
+//            }
             self.view.layoutIfNeeded()
         }
     }

--- a/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
+++ b/Scene/ChallengeCertificateScene/Sources/ChallengeCertificateScene/ChallengeCertificateViewController.swift
@@ -102,7 +102,8 @@ final class ChallengeCertificateViewController: UIViewController, BottomSheetVie
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let v = SelfSizingScrollView(maxHeight: UIScreen.main.bounds.height * 0.72)
+        let heightRatio = UIDevice.current.deviceType == .default ? 0.85 : 0.72
+        let v = SelfSizingScrollView(maxHeightRatio: heightRatio)
         v.delegate = self
         v.addTapAction { [weak self] in
             self?.view.endEditing(true)
@@ -198,6 +199,13 @@ extension ChallengeCertificateViewController: TTTextViewDelegate,
                 make.bottom.equalToSuperview().inset(keyboardFrame.height)
             }
             self.backScrollView.contentOffset.y = keyboardFrame.height
+            let bottomOffset = keyboardFrame.height + 14
+            self.commitButton.snp.remakeConstraints { make in
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().inset(24)
+                make.height.equalTo(57)
+                make.bottom.equalTo(self.view.snp.bottom).inset(bottomOffset)
+            }
             self.view.layoutIfNeeded()
         }
     }

--- a/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
+++ b/Scene/HomeScene/Sources/HomeScene/Views/ChallengeCompletedView.swift
@@ -112,7 +112,7 @@ final class ChallengeCompletedView: UIView {
             make.trailing.equalToSuperview().inset(24)
         }
         
-        let flowerBottomOffset = UIDevice.current.deviceType == .default ? -12 : 33
+        let flowerBottomOffset = UIDevice.current.deviceType == .default ? 12 : 33
         
         // --> PartnerFlower
         self.partnerFlowerTopView.snp.makeConstraints { make in
@@ -143,10 +143,10 @@ final class ChallengeCompletedView: UIView {
             make.trailing.equalToSuperview()
             make.bottom.equalTo(self.confirmButton.snp.top).offset(-flowerBottomOffset)
         }
-
+        let bottomInset = UIDevice.current.deviceType == .default ? 20 : 49
         self.confirmButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.bottom.equalToSuperview().inset(49)
+            make.bottom.equalToSuperview().inset(bottomInset)
             make.width.equalTo(177)
         }
     }

--- a/Scene/NudgeSendScene/Sources/NudgeSendScene/NudgeSendViewController.swift
+++ b/Scene/NudgeSendScene/Sources/NudgeSendScene/NudgeSendViewController.swift
@@ -43,7 +43,8 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
     }()
     
     private lazy var messageTextView: TTTextView = {
-        let v = TTTextView(placeHolder: "찌르기 문구를 입력해주세요.\n최대 30자까지 입력 가능", maxCount: 30)
+        let v = TTTextView(placeHolder: "찌르기 문구를 입력해주세요.\n최대 30자까지 입력 가능", 
+                           maxCount: 30)
         v.customDelegate = self
         return v
     }()
@@ -71,7 +72,8 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let v = SelfSizingScrollView()
+        let heightRatio = UIDevice.current.deviceType == .default ? 0.8 : 0.67
+        let v = SelfSizingScrollView(maxHeightRatio: heightRatio)
         v.addSubview(self.scrollSizeFitView)
         return v
     }()
@@ -82,6 +84,8 @@ final class NudgeSendViewController: UIViewController, BottomSheetViewController
         super.viewDidLoad()
         self.setUI()
         self.messageTextView.becomeFirstResponder()
+        self.registKeyboardDelegate()
+
         Task {
             await self.interactor.didLoad()
         }
@@ -175,5 +179,24 @@ extension NudgeSendViewController: NudgeSendDisplayLogic {
         viewModel.message.unwrap {
             Toast.shared.makeToast($0)
         }
+    }
+}
+
+extension NudgeSendViewController: KeyboardDelegate {
+    func willShowKeyboard(keyboardFrame: CGRect, duration: Double) {
+        let bottomOffset = keyboardFrame.height + 14
+        UIView.animate(withDuration: duration) {
+            self.pushButton.snp.remakeConstraints { make in
+                make.leading.equalToSuperview().offset(24)
+                make.trailing.equalToSuperview().inset(24)
+                make.height.equalTo(57)
+                make.bottom.equalTo(self.view.snp.bottom).inset(bottomOffset)
+            }
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    func willHideKeyboard(duration: Double) {
+        // 키보드 안내려가게 고정해둠
     }
 }


### PR DESCRIPTION
## 개요
SE 기기에서 바텀시트 올라갈 때 버튼 가리는 이슈 해결합니다.
## 변경사항
- 찌르기 바텀시트 SE 대응
- 인증하기 바텀시트 SE 대응
## 스크린샷
https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/b3e4839b-e18c-4ed2-a235-03ef69c0ae09

