### PR TITLE
바텀시트 높이가 고정되지 않는 이슈 해결

### DIFF
--- a/Scene/ChallengeCreateScene/Sources/ChallengeRecommendScene/ChallengeRecommendViewController.swift
+++ b/Scene/ChallengeCreateScene/Sources/ChallengeRecommendScene/ChallengeRecommendViewController.swift
@@ -55,7 +55,8 @@ final class ChallengeRecommendViewController: UIViewController, BottomSheetViewC
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let v = SelfSizingScrollView()
+        let heightRatio = UIDevice.current.deviceType == .default ? 0.8 : 0.67
+        let v = SelfSizingScrollView(maxHeightRatio: heightRatio)
         v.addSubview(self.scrollSizeFitView)
         v.delegate = self
         v.addTapAction { [weak self] in

--- a/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
+++ b/Scene/PraiseSendScene/Sources/PraiseSendScene/PraiseSendViewController.swift
@@ -76,7 +76,8 @@ final class PraiseSendViewController: UIViewController, BottomSheetViewControlle
     }()
     
     private lazy var backScrollView: UIScrollView = {
-        let v = SelfSizingScrollView()
+        let heightRatio = UIDevice.current.deviceType == .default ? 0.8 : 0.67
+        let v = SelfSizingScrollView(maxHeightRatio: heightRatio)
         v.addSubview(self.scrollSizeFitView)
         return v
     }()


### PR DESCRIPTION
## 개요
바텀시트 높이가 고정되지 않는 이슈 해결합니다.
## 변경사항
- 칭찬하기 바텀시트
- 챌린지 추천 바텀시트
## 스크린샷
### Before
<img width="397" alt="스크린샷 2024-01-31 오후 9 47 49" src="https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/589d9871-2608-4af7-8cfb-e22bb30565c0">

### After
https://github.com/mash-up-kr/TwoToo_iOS/assets/37897873/1a56e5e6-0480-4162-a967-0dc0584f5ef3

